### PR TITLE
Taskfile: Exclude emsdk caches from checksums.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ You can use GitHub issues to [request features][feature-req] or [report bugs][bu
 * CMake 3.16 or higher
 * GNU Make
 * Python 3
-* [Task]
+* [Task] 3.38.0 or higher, where [References](https://taskfile.dev/usage/#referencing-other-variables) are available as 
+a non-experimental feature.
 
 ## Setup
 Initialize and update submodules:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ You can use GitHub issues to [request features][feature-req] or [report bugs][bu
 * CMake 3.16 or higher
 * GNU Make
 * Python 3
-* [Task] 3.38.0 or higher, where [References](https://taskfile.dev/usage/#referencing-other-variables) are available as 
-a non-experimental feature.
+* [Task] 3.38.0 or higher
 
 ## Setup
 Initialize and update submodules:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,11 +68,15 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
           EXCLUDE_PATHS: &emsdk_checksum_exclude_paths
+            - "upstream/emscripten/__pycache__"
             - "upstream/emscripten/cache/sanity.txt"
             - "upstream/emscripten/cache/symbol_lists"
             - "upstream/emscripten/cache/symbol_lists.lock"
             - "upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/lto"
+            - "upstream/emscripten/third_party/leb128/__pycache__"
             - "upstream/emscripten/tools/__pycache__"
+            - "upstream/emscripten/tools/ports/__pycache__"
+            - "upstream/emscripten/tools/ports/contrib/__pycache__"
     cmds:
       - task: "clean-emsdk"
       - "git clone 'https://github.com/emscripten-core/emsdk.git' '{{.G_EMSDK_DIR}}'"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,7 +55,6 @@ tasks:
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
   emsdk:
-    run: "once"
     vars:
       CHECKSUM_FILE: "{{.G_EMSDK_CHECKSUM}}"
       OUTPUT_DIR: "{{.G_EMSDK_DIR}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,7 @@ tasks:
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
   emsdk:
+    run: "once"
     vars:
       CHECKSUM_FILE: "{{.G_EMSDK_CHECKSUM}}"
       OUTPUT_DIR: "{{.G_EMSDK_DIR}}"
@@ -66,6 +67,12 @@ tasks:
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
+          EXCLUDE_PATHS: &emsdk_checksum_exclude_paths
+            - "upstream/emscripten/cache/sanity.txt"
+            - "upstream/emscripten/cache/symbol_lists"
+            - "upstream/emscripten/cache/symbol_lists.lock"
+            - "upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/lto"
+            - "upstream/emscripten/tools/__pycache__"
     cmds:
       - task: "clean-emsdk"
       - "git clone 'https://github.com/emscripten-core/emsdk.git' '{{.G_EMSDK_DIR}}'"
@@ -78,6 +85,7 @@ tasks:
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          EXCLUDE_PATHS: *emsdk_checksum_exclude_paths
 
   init:
     internal: true


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
#1 added a Taskfile to set up emsdk. In the `emsdk` task, it downloads an SDK, calls task compute-checksum, and compiles some code with the SDK. However, during the compilation, there are cache files produced within the SDK directory. When developers reruns the Taskfile, the checksum validation tasks fails on the SDK directory and causes the SDK to be re-downloaded and the code to be re-compiled, which voids the effort to avoid unnecessary reprocessing.

## Changes
1. Update tools/yscope-dev-utils to 92cd10da59a6c2fa5c5182ff7ca0c3d7862a7113, where a new parameter is added in `compute-checksum` and `validate-checksum` to exclude certain files from checksum computations.
2. Update Taskfile.yml to specify the cache files to be excluded from checksummings.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
