### PR TITLE
Generate TypeScript definition file for the ClpFfiJs module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ FetchContent_MakeAvailable(Boost)
 message("Boost sources successfully fetched into ${boost_SOURCE_DIR}")
 
 set(CLP_FFI_JS_BIN_NAME
-    "ClpFfijs"
+    "ClpFfiJs"
     CACHE STRING
     "Binary name for the generated .js and .wasm files."
 )
@@ -101,6 +101,7 @@ target_link_options(
         -sEXPORT_ES6
         -sMODULARIZE
         -sWASM_BIGINT
+        --emit-tsd ${CLP_FFI_JS_BIN_NAME}Interface.d.ts
 )
 target_link_libraries(${CLP_FFI_JS_BIN_NAME} PRIVATE embind)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_options(
         -sEXPORT_ES6
         -sMODULARIZE
         -sWASM_BIGINT
-        --emit-tsd ${CLP_FFI_JS_BIN_NAME}Interface.d.ts
+        --emit-tsd ${CLP_FFI_JS_BIN_NAME}.d.ts
 )
 target_link_libraries(${CLP_FFI_JS_BIN_NAME} PRIVATE embind)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
       - "mkdir -p '{{.OUTPUT_DIR}}'"
       - |-
         cmake -S "{{.ROOT_DIR}}" -B "{{.OUTPUT_DIR}}" -G "Unix Makefiles"
-        cmake --build "{{.OUTPUT_DIR}}" --parallel --target ClpFfijs
+        cmake --build "{{.OUTPUT_DIR}}" --parallel --target ClpFfiJ s
       # This command must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
       - "mkdir -p '{{.OUTPUT_DIR}}'"
       - |-
         cmake -S "{{.ROOT_DIR}}" -B "{{.OUTPUT_DIR}}" -G "Unix Makefiles"
-        cmake --build "{{.OUTPUT_DIR}}" --parallel --target ClpFfiJ s
+        cmake --build "{{.OUTPUT_DIR}}" --parallel --target ClpFfiJs
       # This command must be last
       - task: "utils:compute-checksum"
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,6 +73,9 @@ tasks:
         cd "{{.G_EMSDK_DIR}}"
         ./emsdk install latest
         ./emsdk activate latest
+      - |-
+        cd "{{.G_EMSDK_DIR}}/upstream/emscripten"
+        PATH=$(echo {{.G_EMSDK_DIR}}/node/*/bin):$PATH npm install
       # This command must be last
       - task: "utils:compute-checksum"
         vars:

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -139,9 +139,9 @@ auto StreamReader::deserialize_range(size_t begin_idx, size_t end_idx) -> size_t
     return m_encoded_log_events.size();
 }
 
-auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsTsType {
+auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodedResultsTsType {
     if (m_encoded_log_events.size() < end_idx || begin_idx >= end_idx) {
-        return DecodeResultsTsType(emscripten::val::null());
+        return DecodedResultsTsType(emscripten::val::null());
     }
 
     std::span const log_events_span{
@@ -192,7 +192,7 @@ auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> Decod
         ++log_num;
     }
 
-    return DecodeResultsTsType(results);
+    return DecodedResultsTsType(results);
 }
 
 StreamReader::StreamReader(
@@ -208,7 +208,7 @@ StreamReader::StreamReader(
 namespace {
 EMSCRIPTEN_BINDINGS(ClpIrStreamReader) {
     emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
-    emscripten::register_type<clp_ffi_js::ir::DecodeResultsTsType>(
+    emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
             "Array<[string, number, number, number]>"
     );
     emscripten::class_<clp_ffi_js::ir::StreamReader>("ClpIrStreamReader")

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -32,7 +32,7 @@ using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 
 namespace clp_ffi_js::ir {
-auto StreamReader::create(emscripten::val const& data_array) -> StreamReader {
+auto StreamReader::create(DataArrayType const& data_array) -> StreamReader {
     auto const length{data_array["length"].as<size_t>()};
     SPDLOG_INFO("StreamReader::create: got buffer of length={}", length);
 
@@ -139,9 +139,9 @@ auto StreamReader::deserialize_range(size_t begin_idx, size_t end_idx) -> size_t
     return m_encoded_log_events.size();
 }
 
-auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> emscripten::val {
+auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultListType {
     if (m_encoded_log_events.size() < end_idx || begin_idx >= end_idx) {
-        return emscripten::val::null();
+        return DecodeResultListType(emscripten::val::null());
     }
 
     std::span const log_events_span{
@@ -192,7 +192,7 @@ auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> emscr
         ++log_num;
     }
 
-    return results;
+    return DecodeResultListType(results);
 }
 
 StreamReader::StreamReader(
@@ -207,6 +207,10 @@ StreamReader::StreamReader(
 
 namespace {
 EMSCRIPTEN_BINDINGS(ClpIrStreamReader) {
+    emscripten::register_type<clp_ffi_js::ir::DataArrayType>("Uint8Array");
+    emscripten::register_type<clp_ffi_js::ir::DecodeResultListType>(
+            "Array<[string, number, number, number]>"
+    );
     emscripten::class_<clp_ffi_js::ir::StreamReader>("ClpIrStreamReader")
             .constructor(
                     &clp_ffi_js::ir::StreamReader::create,

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -139,9 +139,9 @@ auto StreamReader::deserialize_range(size_t begin_idx, size_t end_idx) -> size_t
     return m_encoded_log_events.size();
 }
 
-auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultListType {
+auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsType {
     if (m_encoded_log_events.size() < end_idx || begin_idx >= end_idx) {
-        return DecodeResultListType(emscripten::val::null());
+        return DecodeResultsType(emscripten::val::null());
     }
 
     std::span const log_events_span{
@@ -192,7 +192,7 @@ auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> Decod
         ++log_num;
     }
 
-    return DecodeResultListType(results);
+    return DecodeResultsType(results);
 }
 
 StreamReader::StreamReader(
@@ -208,7 +208,7 @@ StreamReader::StreamReader(
 namespace {
 EMSCRIPTEN_BINDINGS(ClpIrStreamReader) {
     emscripten::register_type<clp_ffi_js::ir::DataArrayType>("Uint8Array");
-    emscripten::register_type<clp_ffi_js::ir::DecodeResultListType>(
+    emscripten::register_type<clp_ffi_js::ir::DecodeResultsType>(
             "Array<[string, number, number, number]>"
     );
     emscripten::class_<clp_ffi_js::ir::StreamReader>("ClpIrStreamReader")

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -32,7 +32,7 @@ using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 
 namespace clp_ffi_js::ir {
-auto StreamReader::create(DataArrayType const& data_array) -> StreamReader {
+auto StreamReader::create(DataArrayTsType const& data_array) -> StreamReader {
     auto const length{data_array["length"].as<size_t>()};
     SPDLOG_INFO("StreamReader::create: got buffer of length={}", length);
 
@@ -139,9 +139,9 @@ auto StreamReader::deserialize_range(size_t begin_idx, size_t end_idx) -> size_t
     return m_encoded_log_events.size();
 }
 
-auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsType {
+auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsTsType {
     if (m_encoded_log_events.size() < end_idx || begin_idx >= end_idx) {
-        return DecodeResultsType(emscripten::val::null());
+        return DecodeResultsTsType(emscripten::val::null());
     }
 
     std::span const log_events_span{
@@ -192,7 +192,7 @@ auto StreamReader::decode_range(size_t begin_idx, size_t end_idx) const -> Decod
         ++log_num;
     }
 
-    return DecodeResultsType(results);
+    return DecodeResultsTsType(results);
 }
 
 StreamReader::StreamReader(
@@ -207,8 +207,8 @@ StreamReader::StreamReader(
 
 namespace {
 EMSCRIPTEN_BINDINGS(ClpIrStreamReader) {
-    emscripten::register_type<clp_ffi_js::ir::DataArrayType>("Uint8Array");
-    emscripten::register_type<clp_ffi_js::ir::DecodeResultsType>(
+    emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
+    emscripten::register_type<clp_ffi_js::ir::DecodeResultsTsType>(
             "Array<[string, number, number, number]>"
     );
     emscripten::class_<clp_ffi_js::ir::StreamReader>("ClpIrStreamReader")

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -15,7 +15,7 @@
 
 namespace clp_ffi_js::ir {
 EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayTsType);
-EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultsTsType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
 
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded
@@ -75,7 +75,7 @@ public:
      * @return null if any log event in the range doesn't exist (e.g., the range exceeds the number
      * of log events in the file).
      */
-    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsTsType;
+    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodedResultsTsType;
 
 private:
     // Constructor

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -14,6 +14,9 @@
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
 namespace clp_ffi_js::ir {
+EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultListType);
+
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded
  * log events.
@@ -27,7 +30,7 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(emscripten::val const& data_array) -> StreamReader;
+    [[nodiscard]] static auto create(DataArrayType const& data_array) -> StreamReader;
 
     // Destructor
     ~StreamReader() = default;
@@ -72,7 +75,7 @@ public:
      * @return null if any log event in the range doesn't exist (e.g., the range exceeds the number
      * of log events in the file).
      */
-    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> emscripten::val;
+    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultListType;
 
 private:
     // Constructor

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -15,7 +15,7 @@
 
 namespace clp_ffi_js::ir {
 EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayType);
-EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultListType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultsType);
 
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded
@@ -75,7 +75,7 @@ public:
      * @return null if any log event in the range doesn't exist (e.g., the range exceeds the number
      * of log events in the file).
      */
-    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultListType;
+    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsType;
 
 private:
     // Constructor

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -14,8 +14,8 @@
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
 namespace clp_ffi_js::ir {
-EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayType);
-EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultsType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayTsType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(DecodeResultsTsType);
 
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded
@@ -30,7 +30,7 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(DataArrayType const& data_array) -> StreamReader;
+    [[nodiscard]] static auto create(DataArrayTsType const& data_array) -> StreamReader;
 
     // Destructor
     ~StreamReader() = default;
@@ -75,7 +75,7 @@ public:
      * @return null if any log event in the range doesn't exist (e.g., the range exceeds the number
      * of log events in the file).
      */
-    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsType;
+    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx) const -> DecodeResultsTsType;
 
 private:
     // Constructor


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Add commands to install Node.js dependencies in the EMSDK.
2. Add `--emit-tsd` to linker options to generate TypeScript definition for type import into JavaScript / TypeScript projects.
3. Fix typo in `CLP_FFI_JS_BIN_NAME` in CMakeLists.txt and update Taskfile correspondingly.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Ran command `task` in project.
2. Observed TypeScript definition file generated in <project-root>/build/clp-ffi-js/ClpFfijsInterface.d.ts` with below content:
  ```ts
  // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
  declare namespace RuntimeExports {
      let HEAPF32: any;
      let HEAPF64: any;
      let HEAP_DATA_VIEW: any;
      let HEAP8: any;
      let HEAPU8: any;
      let HEAP16: any;
      let HEAPU16: any;
      let HEAP32: any;
      let HEAPU32: any;
      let HEAP64: any;
      let HEAPU64: any;
  }
  interface WasmModule {
  }
  
  export interface ClpIrStreamReader {
    getNumEventsBuffered(): number;
    deserializeRange(_0: number, _1: number): number;
    decodeRange(_0: number, _1: number): any;
    delete(): void;
  }
  
  interface EmbindModule {
    ClpIrStreamReader: {new(_0: any): ClpIrStreamReader};
  }
  
  export type MainModule = WasmModule & typeof RuntimeExports & EmbindModule;
  export default function MainModuleFactory (options?: unknown): Promise<MainModule>;
  
  ```