### PR TITLE
Lock emsdk version to 3.1.67 to work around #6.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,7 +81,13 @@ tasks:
             - "upstream/emscripten/tools/ports/contrib/__pycache__"
     cmds:
       - task: "clean-emsdk"
-      - "git clone 'https://github.com/emscripten-core/emsdk.git' '{{.G_EMSDK_DIR}}'"
+      - >-
+        git clone
+        https://github.com/emscripten-core/emsdk.git
+        --branch 3.1.68
+        --single-branch
+        --recurse-submodules
+        "{{.G_EMSDK_DIR}}"
       - |-
         cd "{{.G_EMSDK_DIR}}"
         ./emsdk install latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,9 +84,9 @@ tasks:
       - >-
         git clone
         https://github.com/emscripten-core/emsdk.git
-        --branch 3.1.68
-        --single-branch
-        --recurse-submodules
+        --branch 3.1.67
+        --depth 1
+        --shallow-submodules
         "{{.G_EMSDK_DIR}}"
       - |-
         cd "{{.G_EMSDK_DIR}}"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The current build uses the main branch of emsdk which at the time of writing causes a build failure due to #6. This PR locks the emsdk version to 3.1.67.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Ran the reproduction instructions in #6 and verified the build succeeded.