### PR TITLE
Add GH workflow to run lint checks daily as well as for every commit and PR.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: "lint"
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,5 +40,12 @@ jobs:
         name: "Install coreutils (for md5sum)"
         run: "brew install coreutils"
 
+      - name: "Log tool versions"
+        run: |-
+          md5sum --version
+          python --version
+          tar --version
+          task --version
+
       - name: "Run lint task"
         run: "task lint:check"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: "lint"
+name: lint
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+name: "lint"
+
+on:
+  pull_request:
+    types: ["opened", "reopened", "synchronize"]
+  push:
+  schedule:
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
+    - cron: "15 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  # So the workflow can cancel in-progress jobs
+  contents: "write"
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+    runs-on: "${{matrix.os}}"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
+
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.8"
+
+      - name: "Install task"
+        run: "npm install -g @go-task/cli"
+
+      - if: "matrix.os == 'macos-latest'"
+        name: "Install coreutils (for md5sum)"
+        run: "brew install coreutils"
+
+      - name: "Run lint task"
+        run: "task lint:check"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds a workflow to run `task lint:check` daily as well as for every commit and PR. This is largely based on the workflows in [y-scope/yscope-log-viewer](https://github.com/y-scope/yscope-log-viewer/blob/main/.github/workflows/lint.yaml) and [y-scope/log-surgeon](https://github.com/y-scope/log-surgeon/blob/main/.github/workflows/lint.yml).

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Validated the workflow ran successfully.
* Added a lint violation in `lint.yaml` and validated the lint workflow failed due to the violation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated linting workflow to enhance code quality checks.
	- The workflow can be triggered automatically on pull requests, pushes, and daily schedules, as well as manually.

- **Improvements**
	- Enhanced efficiency with concurrency settings to manage in-progress jobs effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->