### PR TITLE
Pass emsdk path from Taskfile to CMake build; Fix emsdk task name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow the steps below to develop and contribute to the project.
 ## Set up
 Before opening the project in an IDE, you'll first need to download and install [emscripten]:
 ```shell
-task emscripten
+task emsdk
 ```
 
 ## Linting

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,8 +50,13 @@ tasks:
     cmds:
       - "mkdir -p '{{.OUTPUT_DIR}}'"
       - |-
-        cmake -S "{{.ROOT_DIR}}" -B "{{.OUTPUT_DIR}}" -G "Unix Makefiles"
-        cmake --build "{{.OUTPUT_DIR}}" --parallel --target "{{.G_CLP_FFI_JS_TARGET_NAME}}"
+        cmake \
+        -G "Unix Makefiles" \
+        -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
+        Emscripten.cmake" \
+        -S "{{.ROOT_DIR}}" \
+        -B "{{.OUTPUT_DIR}}"
+      - "cmake --build '{{.OUTPUT_DIR}}' --parallel --target '{{.G_CLP_FFI_JS_TARGET_NAME}}'"
       # This command must be last
       - task: "utils:compute-checksum"
         vars:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Currently, the `emsdk` path in the Taskfile and the one in CMakeLists.txt (for `CMAKE_TOOLCHAIN_FILE`) are both set to `build/emsdk`; this means changing one requires changing the other. Instead, this PR sets `CMAKE_TOOLCHAIN_FILE` when configuring the CMake project in the Taskfile.

Of course, for IDEs that use CMakeLists.txt directly, they will use the hard-coded path in the CMakeLists.txt which may be out of sync with the one in the Taskfile. Ideally, both the Taskfile and CMakeLists.txt could read from some kind of `.env` file, but that seems like more work than it's worth.

This PR also corrects the `emsdk` task name in the README.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* `task clp-ffi-js` succeeded.
* Changed `G_EMSDK_DIR` in the Taskfile and `task clp-ffi-js` still succeeded.
