### PR TITLE
Add tasks to perform C++ linting with clang-format v18.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,1 +1,2 @@
+clang-format>=18.1.5
 yamllint>=1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,3 @@
-clang-format>=18.1.5
+# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
+clang-format~=18.1
 yamllint>=1.35.1

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,19 +1,42 @@
 version: "3"
 
 vars:
+  G_SRC_CLP_FFI_JS_DIR: "{{.ROOT_DIR}}/src/clp_ffi_js"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
   check:
     cmds:
+      - task: "cpp-check"
       - task: "yml-check"
 
   fix:
     cmds:
+      - task: "cpp-fix"
       - task: "yml-fix"
 
   cpp-configs:
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
+
+  cpp-check:
+    sources: &cpp_source_files
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/.clang-format"
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
+      - "{{.TASKFILE}}"
+      - "tools/yscope-dev-utils/lint-configs/.clang-format"
+    cmds:
+      - task: "clang-format"
+        vars:
+          FLAGS: "--dry-run"
+
+  cpp-fix:
+    sources: *cpp_source_files
+    cmds:
+      - task: "clang-format"
+        vars:
+          FLAGS: "-i"
 
   yml:
     aliases:
@@ -29,6 +52,20 @@ tasks:
           .github \
           lint-tasks.yml \
           Taskfile.yml
+
+  clang-format:
+    internal: true
+    requires:
+      vars: ["FLAGS"]
+    deps: ["cpp-configs", "venv"]
+    cmds:
+      - |-
+        . "{{.G_LINT_VENV_DIR}}/bin/activate"
+        find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
+          -type f \
+          \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
+          -print0 | \
+            xargs -0 clang-format {{.FLAGS}} -Werror
 
   venv:
     internal: true


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds the `lint:cpp-check` and `lint:cpp-fix` tasks to perform C++ linting. Currently, the tasks only run clang-format but clang-tidy will be added in a subsequent PR.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* `task lint:check` succeeded.
* `task lint:fix` succeeded.
* `task lint:cpp-check` succeeded.
* `task lint:cpp-fix` succeeded.
* Added a lint violation in `src/clp_ffi_js/ir/StreamReader.cpp` and then:
  * `task lint:check` detected the violation.
  * `task lint:cpp-check` detected the violation.
  * `task lint:fix` fixed the violation.
  * `task lint:cpp-fix` fixed the violation.
* Lint workflow succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced C++ linting and formatting tasks to enhance code quality.
	- Added `clang-format` requirement for improved C++ code formatting.
	- New tasks for C++ and YAML checks and fixes have been implemented.

- **Improvements**
	- Enhanced linting capabilities with new commands for C++ and YAML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->