### PR TITLE
Add tasks to run C++ static analysis using clang-tidy; Separate CMake project config into its own task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ task lint:fix
 
 ### Running specific linters
 The commands above run all linting checks, but for performance you may want to run a subset (e.g.,
-if you only changed C+ files, you don't need to run the YAML linting checks) using one of the tasks
+if you only changed C++ files, you don't need to run the YAML linting checks) using one of the tasks
 in the table below.
 
 | Task                    | Description                                              |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ To run all linting checks AND automatically fix any fixable issues:
 task lint:fix
 ```
 
+### Running specific linters
+The commands above run all linting checks, but for performance you may want to run a subset (e.g.,
+if you only changed C+ files, you don't need to run the YAML linting checks) using one of the tasks
+in the table below.
+
+| Task                    | Description                                              |
+|-------------------------|----------------------------------------------------------|
+| `lint:cpp-check`        | Runs the C++ linters (formatters and static analyzers).  |
+| `lint:cpp-fix`          | Runs the C++ linters and fixes some violations.          |
+| `lint:cpp-format-check` | Runs the C++ formatters.                                 |
+| `lint:cpp-format-fix`   | Runs the C++ formatters and fixes some violations.       |
+| `lint:cpp-static-check` | Runs the C++ static analyzers.                           |
+| `lint:cpp-static-fix`   | Runs the C++ static analyzers and fixes some violations. |
+| `lint:yml-check`        | Runs the YAML linters.                                   |
+| `lint:yml-fix`          | Runs the YAML linters and fixes some violations.         |
+
 [bug-report]: https://github.com/y-scope/clp-ffi-js/issues/new?labels=bug&template=bug-report.yml
 [CLP]: https://github.com/y-scope/clp
 [emscripten]: https://emscripten.org

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,24 +57,6 @@ tasks:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
-  config-cmake-project:
-    internal: true
-    sources:
-      - "{{.G_EMSDK_CHECKSUM}}"
-      - "{{.TASKFILE}}"
-      - "CMakeLists.txt"
-    generates:
-      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/CMakeCache.txt"
-      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
-    deps: ["emsdk"]
-    cmd: |-
-      cmake \
-      -G "Unix Makefiles" \
-      -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
-      Emscripten.cmake" \
-      -S "{{.ROOT_DIR}}" \
-      -B "{{.G_CLP_FFI_JS_BUILD_DIR}}"
-
   emsdk:
     vars:
       CHECKSUM_FILE: "{{.G_EMSDK_CHECKSUM}}"
@@ -143,6 +125,24 @@ tasks:
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+
+  config-cmake-project:
+    internal: true
+    sources:
+      - "{{.G_EMSDK_CHECKSUM}}"
+      - "{{.TASKFILE}}"
+      - "CMakeLists.txt"
+    generates:
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/CMakeCache.txt"
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
+    deps: ["emsdk"]
+    cmd: |-
+      cmake \
+      -G "Unix Makefiles" \
+      -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
+      Emscripten.cmake" \
+      -S "{{.ROOT_DIR}}" \
+      -B "{{.G_CLP_FFI_JS_BUILD_DIR}}"
 
   init:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,6 +36,7 @@ tasks:
       CHECKSUM_FILE: "{{.G_CLP_FFI_JS_CHECKSUM}}"
       OUTPUT_DIR: "{{.G_CLP_FFI_JS_BUILD_DIR}}"
     sources:
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/CMakeCache.txt"
       - "{{.G_EMSDK_CHECKSUM}}"
       - "{{.TASKFILE}}"
       - "CMakeLists.txt"
@@ -58,6 +59,13 @@ tasks:
 
   config-cmake-project:
     internal: true
+    sources:
+      - "{{.G_EMSDK_CHECKSUM}}"
+      - "{{.TASKFILE}}"
+      - "CMakeLists.txt"
+    generates:
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/CMakeCache.txt"
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
     deps: ["emsdk"]
     cmd: |-
       cmake \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,20 +48,24 @@ tasks:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_DIR: "{{.OUTPUT_DIR}}"
     cmds:
-      - "mkdir -p '{{.OUTPUT_DIR}}'"
-      - |-
-        cmake \
-        -G "Unix Makefiles" \
-        -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
-        Emscripten.cmake" \
-        -S "{{.ROOT_DIR}}" \
-        -B "{{.OUTPUT_DIR}}"
+      - task: "config-cmake-project"
       - "cmake --build '{{.OUTPUT_DIR}}' --parallel --target '{{.G_CLP_FFI_JS_TARGET_NAME}}'"
       # This command must be last
       - task: "utils:compute-checksum"
         vars:
           DATA_DIR: "{{.OUTPUT_DIR}}"
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+
+  config-cmake-project:
+    internal: true
+    deps: ["emsdk"]
+    cmd: |-
+      cmake \
+      -G "Unix Makefiles" \
+      -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
+      Emscripten.cmake" \
+      -S "{{.ROOT_DIR}}" \
+      -B "{{.G_CLP_FFI_JS_BUILD_DIR}}"
 
   emsdk:
     vars:
@@ -71,6 +75,7 @@ tasks:
       OUTPUT_DIR: "{{.G_EMSDK_DIR}}"
     sources: ["{{.TASKFILE}}"]
     generates: ["{{.CHECKSUM_FILE}}"]
+    run: "once"
     deps:
       - "init"
       - task: "utils:validate-checksum"

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,4 @@
 # Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
+clang-tidy>=19.1.0
 yamllint>=1.35.1

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -101,6 +101,8 @@ tasks:
         --config-file=.clang-tidy
     deps: [":config-cmake-project", "cpp-configs", "venv"]
     cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+
       # Pass emscripten's cflags to clang-tidy by prefixing each one with `--extra-arg`
       EXTRA_ARGS=$("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
         | tr ' ' '\n' \

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,7 +1,8 @@
 version: "3"
 
 vars:
-  G_SRC_CLP_FFI_JS_DIR: "{{.ROOT_DIR}}/src/clp_ffi_js"
+  G_SRC_DIR: "{{.ROOT_DIR}}/src"
+  G_SRC_CLP_FFI_JS_DIR: "{{.G_SRC_DIR}}/clp_ffi_js"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
@@ -37,6 +38,7 @@ tasks:
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
       - "{{.TASKFILE}}"
       - "tools/yscope-dev-utils/lint-configs/.clang-format"
+    deps: ["cpp-configs", "venv"]
     cmds:
       - task: "clang-format"
         vars:
@@ -44,6 +46,7 @@ tasks:
 
   cpp-format-fix:
     sources: *cpp_format_source_files
+    deps: ["cpp-configs", "venv"]
     cmds:
       - task: "clang-format"
         vars:
@@ -56,12 +59,21 @@ tasks:
     # fix them.
     aliases: ["cpp-static-fix"]
     sources:
+      # Dependency sources
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/_deps/*-src/**/*"
+      - "{{.G_SRC_DIR}}/submodules/**/*"
+
+      # clp-ffi-js sources
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
+
+      # Other sources
+      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
+      - "{{.ROOT_DIR}}/Taskfile.yml"
       - "{{.TASKFILE}}"
-      - "CMakeLists.txt"
       - "tools/yscope-dev-utils/lint-configs/.clang-tidy"
+    deps: [":config-cmake-project", "cpp-configs", "venv"]
     cmds:
       - task: "clang-tidy"
 
@@ -84,7 +96,6 @@ tasks:
     internal: true
     requires:
       vars: ["FLAGS"]
-    deps: ["cpp-configs", "venv"]
     cmd: |-
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
       find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
@@ -99,7 +110,6 @@ tasks:
       FLAGS: >-
         -p {{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json
         --config-file=.clang-tidy
-    deps: [":config-cmake-project", "cpp-configs", "venv"]
     cmd: |-
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
 

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -17,7 +17,6 @@ tasks:
       - task: "yml-fix"
 
   cpp-configs:
-    run: "once"
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
 
   cpp-check:
@@ -134,7 +133,6 @@ tasks:
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]
-    run: "once"
     deps:
       - ":init"
       - task: ":utils:validate-checksum"

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -16,10 +16,21 @@ tasks:
       - task: "yml-fix"
 
   cpp-configs:
+    run: "once"
     cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
 
   cpp-check:
-    sources: &cpp_source_files
+    cmds:
+      - task: "cpp-format-check"
+      - task: "cpp-static-check"
+
+  cpp-fix:
+    cmds:
+      - task: "cpp-format-fix"
+      - task: "cpp-static-fix"
+
+  cpp-format-check:
+    sources: &cpp_format_source_files
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/.clang-format"
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
       - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
@@ -31,12 +42,28 @@ tasks:
         vars:
           FLAGS: "--dry-run"
 
-  cpp-fix:
-    sources: *cpp_source_files
+  cpp-format-fix:
+    sources: *cpp_format_source_files
     cmds:
       - task: "clang-format"
         vars:
           FLAGS: "-i"
+
+  cpp-static-check:
+    # Alias task to `cpp-static-fix` since we don't currently support automatic fixes.
+    # NOTE: clang-tidy does have the ability to fix some errors, but the fixes can be inaccurate.
+    # When we eventually determine which errors can be safely fixed, we'll allow clang-tidy to
+    # fix them.
+    aliases: ["cpp-static-fix"]
+    sources:
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
+      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
+      - "{{.TASKFILE}}"
+      - "CMakeLists.txt"
+      - "tools/yscope-dev-utils/lint-configs/.clang-tidy"
+    cmds:
+      - task: "clang-tidy"
 
   yml:
     aliases:
@@ -58,14 +85,32 @@ tasks:
     requires:
       vars: ["FLAGS"]
     deps: ["cpp-configs", "venv"]
-    cmds:
-      - |-
-        . "{{.G_LINT_VENV_DIR}}/bin/activate"
-        find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
-          -type f \
-          \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
-          -print0 | \
-            xargs -0 clang-format {{.FLAGS}} -Werror
+    cmd: |-
+      . "{{.G_LINT_VENV_DIR}}/bin/activate"
+      find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
+        -type f \
+        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
+        -print0 | \
+          xargs -0 clang-format {{.FLAGS}} -Werror
+
+  clang-tidy:
+    internal: true
+    vars:
+      FLAGS: >-
+        -p {{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json
+        --config-file=.clang-tidy
+    deps: [":config-cmake-project", "cpp-configs", "venv"]
+    cmd: |-
+      # Pass emscripten's cflags to clang-tidy by prefixing each one with `--extra-arg`
+      EXTRA_ARGS=$("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
+        | tr ' ' '\n' \
+        | sed 's/^/--extra-arg /' \
+        | tr '\n' ' ')
+      find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
+        -type f \
+        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
+        -print0 | \
+          xargs -0 clang-tidy {{.FLAGS}} $EXTRA_ARGS
 
   venv:
     internal: true
@@ -77,6 +122,7 @@ tasks:
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]
+    run: "once"
     deps:
       - ":init"
       - task: ":utils:validate-checksum"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds tasks to run clang-tidy on our C++ code. Since clang-tidy is quite slow, we separate the C++ linting tasks into formatters and static analyzers. The updates to the README describe the new tasks.

We plan to parallelize clang-tidy's checking but it's more work than can be done in this scope of this PR. Similarly (also noted in the code), we currently don't support automated clang-tidy fixes since they can be inaccurate.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Renamed `StreamReader::m_ts_pattern` to `StreamReader::mTsPattern` and then:
  * `task lint:check` failed due to the naming violation.
  * `task lint:cpp-check` failed due to the naming violation.
  * `task lint:cpp-static-check` failed due to the naming violation.
  * `task lint:fix` failed due to the naming violation.
  * `task lint:cpp-fix` failed due to the naming violation.
  * `task lint:cpp-static-fix` failed due to the naming violation.
* Added extra whitespace in StreamReader.hpp ad then:
  * `task lint:check` failed due to the violation.
  * `task lint:cpp-check` failed due to the violation.
  * `task lint:cpp-format-check` failed due to the violation.
  * `task lint:fix` failed due to the violation.
  * `task lint:cpp-fix` removed the extra whitespace.
  * `task lint:cpp-format-check` removed the extra whitespace.
* Ran `task lint:cpp-check` twice to ensure no checks were re-run, changed one of the submodules, and then `task lint:cpp-check` detected the changes and re-ran `cpp-static-check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added detailed linting commands for C++ and YAML in the README.md.
	- Introduced new linting tasks: `cpp-format-check`, `cpp-static-check`, and `clang-tidy` in the linting configuration.
- **Bug Fixes**
	- Enhanced structure and readability of linting tasks configuration.
- **Chores**
	- Updated dependencies to include `clang-tidy` and maintained existing versions for other linting tools.
	- Streamlined the build process with the introduction of the `config-cmake-project` task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->