### PR TITLE
Allow using other CMake generators besides "Unix Makefiles".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,6 @@ project(
     VERSION 0.1.0
 )
 
-# Enforce "Unix Makefiles" because "Ninja" does not work with the Emscripten toolchain on CXX_20
-# sources.
-if(NOT CMAKE_GENERATOR MATCHES "Unix Makefiles")
-    message(
-        FATAL_ERROR
-        "This project is intended to be built with Unix Makefiles on a Unix system."
-    )
-endif()
-
 # Enable exporting compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,7 +51,6 @@ tasks:
       - "mkdir -p '{{.OUTPUT_DIR}}'"
       - |-
         cmake \
-        -G "Unix Makefiles" \
         -DCMAKE_TOOLCHAIN_FILE="{{.G_EMSDK_DIR}}/upstream/emscripten/cmake/Modules/Platform/\
         Emscripten.cmake" \
         -S "{{.ROOT_DIR}}" \


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Previously, it was mandated in CMakeList.txt that only `Unix Makefiles` generators can be used because compilation errors were observed with code that references C++-20 headers. It is confirmed that now with Ninja generators, the `clp-ffi-js` code compiles fine with Emsdk @ 3.1.67 .

1. Remove "Unix Makefiles" `CMAKE_GENERATOR` check.
2. Eliminate the generator specification from compilation commands in Taskfile.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. On a Mac computer.
    1. Ran `task clp-ffi-js` and observed compilation success.
    2. Added a semantically meaningless newline at the end of StreamReader.cpp and ran `task clp-ffi-js` again. Observed the source code getting compiled and the overall compilation succeeded.
2. On an Ubuntu 20.04 computer, repeat above validation steps. (In my case, I was using WSL. )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified build configuration by allowing various generators without restrictions.
	- Introduced new variables in task definitions for improved build clarity and reliability.
- **Bug Fixes**
	- Enhanced handling of the Boost library version for better compatibility.
- **Chores**
	- Updated task commands to ensure a clean build environment and consistent checksum validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->