### PR TITLE
Refactor `StreamReaderDataContext` to encapsulate readers instead of zstd decompressors; Change its template type to deserializer.

### DIFF
--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -30,11 +30,11 @@
 #include <clp_ffi_js/ir/LogEventWithLevel.hpp>
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
+namespace clp_ffi_js::ir {
 using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 using clp::ir::LogEventDeserializer;
 
-namespace clp_ffi_js::ir {
 auto StreamReader::create(DataArrayTsType const& data_array) -> StreamReader {
     auto const length{data_array["length"].as<size_t>()};
     SPDLOG_INFO("StreamReader::create: got buffer of length={}", length);

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -32,6 +32,7 @@
 
 using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
+using clp::ir::LogEventDeserializer;
 
 namespace clp_ffi_js::ir {
 auto StreamReader::create(DataArrayTsType const& data_array) -> StreamReader {
@@ -89,11 +90,12 @@ auto StreamReader::create(DataArrayTsType const& data_array) -> StreamReader {
         };
     }
 
-    StreamReaderDataContext<four_byte_encoded_variable_t> stream_reader_data_context{
-            std::move(data_buffer),
-            std::move(zstd_decompressor),
-            std::move(result.value())
-    };
+    StreamReaderDataContext<LogEventDeserializer<four_byte_encoded_variable_t>>
+            stream_reader_data_context{
+                    std::move(data_buffer),
+                    std::move(zstd_decompressor),
+                    std::move(result.value())
+            };
     return StreamReader{std::move(stream_reader_data_context)};
 }
 
@@ -244,10 +246,11 @@ auto StreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filte
 }
 
 StreamReader::StreamReader(
-        StreamReaderDataContext<four_byte_encoded_variable_t>&& stream_reader_data_context
+        StreamReaderDataContext<LogEventDeserializer<four_byte_encoded_variable_t>>&&
+                stream_reader_data_context
 )
         : m_stream_reader_data_context{std::make_unique<
-                  StreamReaderDataContext<four_byte_encoded_variable_t>>(
+                  StreamReaderDataContext<LogEventDeserializer<four_byte_encoded_variable_t>>>(
                   std::move(stream_reader_data_context)
           )},
           m_ts_pattern{m_stream_reader_data_context->get_deserializer().get_timestamp_pattern()} {}

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -14,10 +14,11 @@
 
 #include <clp_ffi_js/ir/LogEventWithLevel.hpp>
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
+
+namespace clp_ffi_js::ir {
 using clp::ir::four_byte_encoded_variable_t;
 using clp::ir::LogEventDeserializer;
 
-namespace clp_ffi_js::ir {
 EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(FilteredLogEventMapTsType);

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -6,8 +6,8 @@
 #include <optional>
 #include <vector>
 
-#include <clp/ir/types.hpp>
 #include <clp/ir/LogEventDeserializer.hpp>
+#include <clp/ir/types.hpp>
 #include <clp/TimestampPattern.hpp>
 #include <emscripten/bind.h>
 #include <emscripten/val.h>

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -7,12 +7,15 @@
 #include <vector>
 
 #include <clp/ir/types.hpp>
+#include <clp/ir/LogEventDeserializer.hpp>
 #include <clp/TimestampPattern.hpp>
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
 #include <clp_ffi_js/ir/LogEventWithLevel.hpp>
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
+using clp::ir::four_byte_encoded_variable_t;
+using clp::ir::LogEventDeserializer;
 
 namespace clp_ffi_js::ir {
 EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayTsType);
@@ -97,12 +100,14 @@ public:
 
 private:
     // Constructor
-    explicit StreamReader(StreamReaderDataContext<clp::ir::four_byte_encoded_variable_t>&&
-                                  stream_reader_data_context);
+    explicit StreamReader(
+            StreamReaderDataContext<LogEventDeserializer<four_byte_encoded_variable_t>>&&
+                    stream_reader_data_context
+    );
 
     // Variables
-    std::vector<LogEventWithLevel<clp::ir::four_byte_encoded_variable_t>> m_encoded_log_events;
-    std::unique_ptr<StreamReaderDataContext<clp::ir::four_byte_encoded_variable_t>>
+    std::vector<LogEventWithLevel<four_byte_encoded_variable_t>> m_encoded_log_events;
+    std::unique_ptr<StreamReaderDataContext<LogEventDeserializer<four_byte_encoded_variable_t>>>
             m_stream_reader_data_context;
     FilteredLogEventsMap m_filtered_log_event_map;
     clp::TimestampPattern m_ts_pattern;

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -10,9 +10,9 @@
 namespace clp_ffi_js::ir {
 /**
  * The data context for a `StreamReader`. It encapsulates a chain of the following resources:
- * A CLP deserializer class that reads from a `clp::ReaderInterface`, which in turn reads from a
+ * A CLP IR deserializer class that reads from a `clp::ReaderInterface`, which in turn reads from a
  * `clp::Array`.
- * @tparam deserializer_t Type of deserializer.
+ * @tparam deserializer_t Type of IR deserializer.
  */
 template <typename deserializer_t>
 class StreamReaderDataContext {

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -40,6 +40,11 @@ public:
 
     // Methods
     /**
+     * @return A reference to the reader.
+     */
+    [[nodiscard]] auto get_reader() -> clp::ReaderInterface& { return *m_reader; }
+
+    /**
      * @return A reference to the deserializer.
      */
     [[nodiscard]] auto get_deserializer() -> deserializer_t& { return m_deserializer; }

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -5,25 +5,23 @@
 #include <utility>
 
 #include <clp/Array.hpp>
-#include <clp/ir/LogEventDeserializer.hpp>
-#include <clp/ir/types.hpp>
 #include <clp/streaming_compression/zstd/Decompressor.hpp>
 
 namespace clp_ffi_js::ir {
 /**
  * The data context for a `StreamReader`. It encapsulates a chain of the following resources:
- * A `clp::ir::LogEventDeserializer` that reads from a
- * `clp::streaming_compression::zstd::Decompressor`, which in turn reads from a `clp::Array`.
- * @tparam encoded_variable_t Type of encoded variables encoded in the stream.
+ * A CLP deserializer class that reads from a `clp::streaming_compression::zstd::Decompressor`,
+ * which in turn reads from a `clp::Array`.
+ * @tparam deserializer_t Type of deserializer.
  */
-template <typename encoded_variable_t>
+template <typename deserializer_t>
 class StreamReaderDataContext {
 public:
     // Constructors
     StreamReaderDataContext(
             clp::Array<char>&& data_buffer,
             std::unique_ptr<clp::streaming_compression::zstd::Decompressor>&& zstd_decompressor,
-            clp::ir::LogEventDeserializer<clp::ir::four_byte_encoded_variable_t> deserializer
+            deserializer_t deserializer
     )
             : m_data_buffer{std::move(data_buffer)},
               m_zstd_decompressor{std::move(zstd_decompressor)},
@@ -44,14 +42,12 @@ public:
     /**
      * @return A reference to the deserializer.
      */
-    [[nodiscard]] auto get_deserializer() -> clp::ir::LogEventDeserializer<encoded_variable_t>& {
-        return m_deserializer;
-    }
+    [[nodiscard]] auto get_deserializer() -> deserializer_t& { return m_deserializer; }
 
 private:
     clp::Array<char> m_data_buffer;
     std::unique_ptr<clp::streaming_compression::zstd::Decompressor> m_zstd_decompressor;
-    clp::ir::LogEventDeserializer<encoded_variable_t> m_deserializer;
+    deserializer_t m_deserializer;
 };
 }  // namespace clp_ffi_js::ir
 

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -5,13 +5,13 @@
 #include <utility>
 
 #include <clp/Array.hpp>
-#include <clp/streaming_compression/zstd/Decompressor.hpp>
+#include <clp/ReaderInterface.hpp>
 
 namespace clp_ffi_js::ir {
 /**
  * The data context for a `StreamReader`. It encapsulates a chain of the following resources:
- * A CLP deserializer class that reads from a `clp::streaming_compression::zstd::Decompressor`,
- * which in turn reads from a `clp::Array`.
+ * A CLP deserializer class that reads from a `clp::ReaderInterface`, which in turn reads from a
+ * `clp::Array`.
  * @tparam deserializer_t Type of deserializer.
  */
 template <typename deserializer_t>
@@ -20,11 +20,11 @@ public:
     // Constructors
     StreamReaderDataContext(
             clp::Array<char>&& data_buffer,
-            std::unique_ptr<clp::streaming_compression::zstd::Decompressor>&& zstd_decompressor,
+            std::unique_ptr<clp::ReaderInterface>&& reader,
             deserializer_t deserializer
     )
             : m_data_buffer{std::move(data_buffer)},
-              m_zstd_decompressor{std::move(zstd_decompressor)},
+              m_reader{std::move(reader)},
               m_deserializer{std::move(deserializer)} {}
 
     // Disable copy constructor and assignment operator
@@ -46,7 +46,7 @@ public:
 
 private:
     clp::Array<char> m_data_buffer;
-    std::unique_ptr<clp::streaming_compression::zstd::Decompressor> m_zstd_decompressor;
+    std::unique_ptr<clp::ReaderInterface> m_reader;
     deserializer_t m_deserializer;
 };
 }  // namespace clp_ffi_js::ir


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Change template type to deserializer in `StreamReaderDataContext`.
2. Use ReaderInterface instead of zstd decompressor in StreamReaderDataContext.
3. Expose the reader in StreamReaderDataContext via a new method get_reader.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Built the js assets with `task` and ran below sample code:
    ```
    import ModuleInit from "./cmake-build-debug/ClpFfiJs.js"
    import fs from "node:fs"
    
    const main = async () => {
        const file = fs.readFileSync("./test.clp.zst")
    
        console.time("perf")
        const Module = await ModuleInit()
        try {
            const decoder = new Module.ClpIrStreamReader(new Uint8Array(file))
            const numEvents = decoder.deserializeStream()
            const results = decoder.decodeRange(0, numEvents, false)
            console.log(results)
    
            decoder.filterLogEvents([5])
    
            const filteredLogEventMap = decoder.getFilteredLogEventMap()
            console.log(filteredLogEventMap)
        } catch (e) {
            console.trace("Exception caught:", e)
        }
        console.timeEnd("perf")
    }
    
    void main()
    ```
2. Observed no error.