### PR TITLE
Add support for deserializing and decoding v0.1.0 IR streams, but without log-level parsing and filtering.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,16 @@ endif()
 
 set(CLP_FFI_JS_SRC_MAIN
     src/clp_ffi_js/ir/StreamReader.cpp
+    src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
     src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
 )
 
 set(CLP_FFI_JS_SRC_CLP_CORE
     src/submodules/clp/components/core/src/clp/ffi/ir_stream/decoding_methods.cpp
+    src/submodules/clp/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
+    src/submodules/clp/components/core/src/clp/ffi/ir_stream/utils.cpp
+    src/submodules/clp/components/core/src/clp/ffi/KeyValuePairLogEvent.cpp
+    src/submodules/clp/components/core/src/clp/ffi/SchemaTree.cpp
     src/submodules/clp/components/core/src/clp/ir/EncodedTextAst.cpp
     src/submodules/clp/components/core/src/clp/ir/LogEventDeserializer.cpp
     src/submodules/clp/components/core/src/clp/ReadOnlyMemoryMappedFile.cpp

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -122,6 +122,12 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     );
 
     // JS types used as outputs
+    emscripten::enum_<clp::ffi::ir_stream::IRProtocolErrorCode>("IRProtocolErrorCode")
+            .value("SUPPORTED", clp::ffi::ir_stream::IRProtocolErrorCode::Supported)
+            .value("BACKWARD_COMPATIBLE",
+                   clp::ffi::ir_stream::IRProtocolErrorCode::BackwardCompatible)
+            .value("UNSUPPORTED", clp::ffi::ir_stream::IRProtocolErrorCode::Unsupported)
+            .value("INVALID", clp::ffi::ir_stream::IRProtocolErrorCode::Invalid);
     emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
             "Array<[string, number, number, number]>"
     );
@@ -130,6 +136,10 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
             .constructor(
                     &clp_ffi_js::ir::StreamReader::create,
                     emscripten::return_value_policy::take_ownership()
+            )
+            .function(
+                    "getIrProtocolErrorCode",
+                    &clp_ffi_js::ir::StreamReader::get_ir_protocol_error_code
             )
             .function(
                     "getNumEventsBuffered",

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -167,12 +167,11 @@ auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const
 
     rewind_reader_and_validate_encoding_type(*zstd_decompressor);
 
-    // Validate the stream's version
+    // Validate the stream's version and decide which type of IR stream reader to create.
     auto pos = zstd_decompressor->get_pos();
     auto const version{get_version(*zstd_decompressor)};
-    auto const version_validation_result{clp::ffi::ir_stream::validate_protocol_version(version)};
-
     try {
+        auto const version_validation_result{clp::ffi::ir_stream::validate_protocol_version(version)};
         if (clp::ffi::ir_stream::IRProtocolErrorCode::Supported == version_validation_result) {
             zstd_decompressor->seek_from_begin(0);
             return std::make_unique<StructuredIrStreamReader>(StructuredIrStreamReader::create(

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -11,7 +11,6 @@
 
 #include <clp/Array.hpp>
 #include <clp/ErrorCode.hpp>
-#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ffi/ir_stream/protocol_constants.hpp>
 #include <clp/ReaderInterface.hpp>
 #include <clp/streaming_compression/zstd/Decompressor.hpp>
@@ -117,9 +116,7 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     // JS types used as inputs
     emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
     emscripten::register_type<clp_ffi_js::ir::LogLevelFilterTsType>("number[] | null");
-    emscripten::register_type<clp_ffi_js::ir::ReaderOptions>(
-            "{timestampKey: string} | null"
-    );
+    emscripten::register_type<clp_ffi_js::ir::ReaderOptions>("{timestampKey: string} | null");
 
     // JS types used as outputs
     emscripten::enum_<clp_ffi_js::ir::IrStreamType>("IrStreamType")

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -24,6 +24,7 @@
 
 #include <clp_ffi_js/ClpFfiJsException.hpp>
 #include <clp_ffi_js/ir/UnstructuredIrStreamReader.hpp>
+#include <clp_ffi_js/ir/StructuredIrStreamReader.hpp>
 
 namespace {
 using ClpFfiJsException = clp_ffi_js::ClpFfiJsException;
@@ -117,6 +118,9 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     // JS types used as inputs
     emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
     emscripten::register_type<clp_ffi_js::ir::LogLevelFilterTsType>("number[] | null");
+    emscripten::register_type<clp_ffi_js::ir::ReaderOptions>(
+            "interface{logLevelKey: string, timestampKey: string} | null"
+    );
 
     // JS types used as outputs
     emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
@@ -143,7 +147,8 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
 }  // namespace
 
 namespace clp_ffi_js::ir {
-auto StreamReader::create(DataArrayTsType const& data_array) -> std::unique_ptr<StreamReader> {
+auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const& reader_options)
+        -> std::unique_ptr<StreamReader> {
     auto const length{data_array["length"].as<size_t>()};
     SPDLOG_INFO("StreamReader::create: got buffer of length={}", length);
 
@@ -162,16 +167,28 @@ auto StreamReader::create(DataArrayTsType const& data_array) -> std::unique_ptr<
     // Validate the stream's version
     auto pos = zstd_decompressor->get_pos();
     auto const version{get_version(*zstd_decompressor)};
-    if (std::ranges::find(cUnstructuredIrVersions, version) == cUnstructuredIrVersions.end()) {
-        throw ClpFfiJsException{
-                clp::ErrorCode::ErrorCode_Unsupported,
-                __FILENAME__,
-                __LINE__,
-                std::format("Unable to create reader for IR stream with version {}.", version)
-        };
+    if (std::ranges::find(cUnstructuredIrVersions, version) != cUnstructuredIrVersions.end()) {
+        try {
+            zstd_decompressor->seek_from_begin(pos);
+        } catch (ZstdDecompressor::OperationFailed& e) {
+            throw ClpFfiJsException{
+                    clp::ErrorCode::ErrorCode_Failure,
+                    __FILENAME__,
+                    __LINE__,
+                    std::format("Unable to rewind zstd decompressor: {}", e.what())
+            };
+        }
+        return std::make_unique<UnstructuredIrStreamReader>(UnstructuredIrStreamReader::create(
+                std::move(zstd_decompressor),
+                std::move(data_buffer)
+        ));
     }
+//    if (clp::ffi::ir_stream::IRProtocolErrorCode_Supported
+//               == clp::ffi::ir_stream::validate_protocol_version(version))
+//    {
+    // FIXME: wait for https://github.com/y-scope/clp/pull/573
     try {
-        zstd_decompressor->seek_from_begin(pos);
+        zstd_decompressor->seek_from_begin(0);
     } catch (ZstdDecompressor::OperationFailed& e) {
         throw ClpFfiJsException{
                 clp::ErrorCode::ErrorCode_Failure,
@@ -180,9 +197,18 @@ auto StreamReader::create(DataArrayTsType const& data_array) -> std::unique_ptr<
                 std::format("Unable to rewind zstd decompressor: {}", e.what())
         };
     }
+        return std::make_unique<StructuredIrStreamReader>(StructuredIrStreamReader::create(
+                std::move(zstd_decompressor),
+                std::move(data_buffer),
+                reader_options
+        ));
+//    }
 
-    return std::make_unique<UnstructuredIrStreamReader>(
-            UnstructuredIrStreamReader::create(std::move(zstd_decompressor), std::move(data_buffer))
-    );
+//    throw ClpFfiJsException{
+//            clp::ErrorCode::ErrorCode_Unsupported,
+//            __FILENAME__,
+//            __LINE__,
+//            std::format("Unable to create reader for IR stream with version {}.", version)
+//    };
 }
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -11,6 +11,7 @@
 
 #include <clp/Array.hpp>
 #include <clp/ErrorCode.hpp>
+#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ffi/ir_stream/protocol_constants.hpp>
 #include <clp/ReaderInterface.hpp>
 #include <clp/streaming_compression/zstd/Decompressor.hpp>

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -23,8 +23,8 @@
 #include <spdlog/spdlog.h>
 
 #include <clp_ffi_js/ClpFfiJsException.hpp>
-#include <clp_ffi_js/ir/UnstructuredIrStreamReader.hpp>
 #include <clp_ffi_js/ir/StructuredIrStreamReader.hpp>
+#include <clp_ffi_js/ir/UnstructuredIrStreamReader.hpp>
 
 namespace {
 using ClpFfiJsException = clp_ffi_js::ClpFfiJsException;
@@ -183,9 +183,9 @@ auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const
                 std::move(data_buffer)
         ));
     }
-//    if (clp::ffi::ir_stream::IRProtocolErrorCode_Supported
-//               == clp::ffi::ir_stream::validate_protocol_version(version))
-//    {
+    //    if (clp::ffi::ir_stream::IRProtocolErrorCode_Supported
+    //               == clp::ffi::ir_stream::validate_protocol_version(version))
+    //    {
     // FIXME: wait for https://github.com/y-scope/clp/pull/573
     try {
         zstd_decompressor->seek_from_begin(0);
@@ -197,18 +197,18 @@ auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const
                 std::format("Unable to rewind zstd decompressor: {}", e.what())
         };
     }
-        return std::make_unique<StructuredIrStreamReader>(StructuredIrStreamReader::create(
-                std::move(zstd_decompressor),
-                std::move(data_buffer),
-                reader_options
-        ));
-//    }
+    return std::make_unique<StructuredIrStreamReader>(StructuredIrStreamReader::create(
+            std::move(zstd_decompressor),
+            std::move(data_buffer),
+            reader_options
+    ));
+    //    }
 
-//    throw ClpFfiJsException{
-//            clp::ErrorCode::ErrorCode_Unsupported,
-//            __FILENAME__,
-//            __LINE__,
-//            std::format("Unable to create reader for IR stream with version {}.", version)
-//    };
+    //    throw ClpFfiJsException{
+    //            clp::ErrorCode::ErrorCode_Unsupported,
+    //            __FILENAME__,
+    //            __LINE__,
+    //            std::format("Unable to create reader for IR stream with version {}.", version)
+    //    };
 }
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -122,12 +122,9 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     );
 
     // JS types used as outputs
-    emscripten::enum_<clp::ffi::ir_stream::IRProtocolErrorCode>("IRProtocolErrorCode")
-            .value("SUPPORTED", clp::ffi::ir_stream::IRProtocolErrorCode::Supported)
-            .value("BACKWARD_COMPATIBLE",
-                   clp::ffi::ir_stream::IRProtocolErrorCode::BackwardCompatible)
-            .value("UNSUPPORTED", clp::ffi::ir_stream::IRProtocolErrorCode::Unsupported)
-            .value("INVALID", clp::ffi::ir_stream::IRProtocolErrorCode::Invalid);
+    emscripten::enum_<clp_ffi_js::ir::IrStreamType>("IrStreamType")
+            .value("STRUCTURED", clp_ffi_js::ir::IrStreamType::Structured)
+            .value("UNSTRUCTURED", clp_ffi_js::ir::IrStreamType::Unstructured);
     emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
             "Array<[string, number, number, number]>"
     );
@@ -137,10 +134,7 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
                     &clp_ffi_js::ir::StreamReader::create,
                     emscripten::return_value_policy::take_ownership()
             )
-            .function(
-                    "getIrProtocolErrorCode",
-                    &clp_ffi_js::ir::StreamReader::get_ir_protocol_error_code
-            )
+            .function("getIrStreamType", &clp_ffi_js::ir::StreamReader::get_ir_stream_type)
             .function(
                     "getNumEventsBuffered",
                     &clp_ffi_js::ir::StreamReader::get_num_events_buffered

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -171,7 +171,8 @@ auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const
     auto pos = zstd_decompressor->get_pos();
     auto const version{get_version(*zstd_decompressor)};
     try {
-        auto const version_validation_result{clp::ffi::ir_stream::validate_protocol_version(version)};
+        auto const version_validation_result{clp::ffi::ir_stream::validate_protocol_version(version)
+        };
         if (clp::ffi::ir_stream::IRProtocolErrorCode::Supported == version_validation_result) {
             zstd_decompressor->seek_from_begin(0);
             return std::make_unique<StructuredIrStreamReader>(StructuredIrStreamReader::create(

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -118,7 +118,7 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
     emscripten::register_type<clp_ffi_js::ir::LogLevelFilterTsType>("number[] | null");
     emscripten::register_type<clp_ffi_js::ir::ReaderOptions>(
-            "{logLevelKey: string, timestampKey: string} | null"
+            "{timestampKey: string} | null"
     );
 
     // JS types used as outputs

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -118,7 +118,7 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     emscripten::register_type<clp_ffi_js::ir::DataArrayTsType>("Uint8Array");
     emscripten::register_type<clp_ffi_js::ir::LogLevelFilterTsType>("number[] | null");
     emscripten::register_type<clp_ffi_js::ir::ReaderOptions>(
-            "interface{logLevelKey: string, timestampKey: string} | null"
+            "{logLevelKey: string, timestampKey: string} | null"
     );
 
     // JS types used as outputs

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -119,9 +119,9 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
     emscripten::register_type<clp_ffi_js::ir::ReaderOptions>("{timestampKey: string} | null");
 
     // JS types used as outputs
-    emscripten::enum_<clp_ffi_js::ir::IrStreamType>("IrStreamType")
-            .value("STRUCTURED", clp_ffi_js::ir::IrStreamType::Structured)
-            .value("UNSTRUCTURED", clp_ffi_js::ir::IrStreamType::Unstructured);
+    emscripten::enum_<clp_ffi_js::ir::StreamType>("IrStreamType")
+            .value("STRUCTURED", clp_ffi_js::ir::StreamType::Structured)
+            .value("UNSTRUCTURED", clp_ffi_js::ir::StreamType::Unstructured);
     emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
             "Array<[string, number, number, number]>"
     );

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -1,10 +1,8 @@
 #ifndef CLP_FFI_JS_IR_STREAMREADER_HPP
 #define CLP_FFI_JS_IR_STREAMREADER_HPP
 
-#include <array>
 #include <cstddef>
 #include <memory>
-#include <string_view>
 
 #include <clp/streaming_compression/zstd/Decompressor.hpp>
 #include <emscripten/val.h>
@@ -18,9 +16,6 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(ReaderOptions);
 // JS types used as outputs
 EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(FilteredLogEventMapTsType);
-
-constexpr std::array<std::string_view, 6> cUnstructuredIrVersions
-        = {"v0.0.2", "v0.0.1", "v0.0.0", "0.0.2", "0.0.1", "0.0.0"};
 
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <memory>
 
-#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/streaming_compression/zstd/Decompressor.hpp>
 #include <emscripten/val.h>
 

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <memory>
 
+#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/streaming_compression/zstd/Decompressor.hpp>
 #include <emscripten/val.h>
 
@@ -50,6 +51,9 @@ public:
     auto operator=(StreamReader&&) -> StreamReader& = delete;
 
     // Methods
+    [[nodiscard]] virtual auto get_ir_protocol_error_code(
+    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode = 0;
+
     /**
      * @return The number of events buffered.
      */

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -13,6 +13,7 @@ namespace clp_ffi_js::ir {
 // JS types used as inputs
 EMSCRIPTEN_DECLARE_VAL_TYPE(DataArrayTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(LogLevelFilterTsType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(ReaderOptions);
 
 // JS types used as outputs
 EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
@@ -36,7 +37,8 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(DataArrayTsType const& data_array
+    [[nodiscard]] static auto create(DataArrayTsType const& data_array,
+                                     ReaderOptions const& reader_options
     ) -> std::unique_ptr<StreamReader>;
 
     // Destructor

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -19,7 +19,7 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(ReaderOptions);
 EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(FilteredLogEventMapTsType);
 
-enum class IrStreamType : uint8_t {
+enum class StreamType : uint8_t {
     Structured,
     Unstructured,
 };
@@ -57,7 +57,7 @@ public:
     auto operator=(StreamReader&&) -> StreamReader& = delete;
 
     // Methods
-    [[nodiscard]] virtual auto get_ir_stream_type() const -> IrStreamType = 0;
+    [[nodiscard]] virtual auto get_ir_stream_type() const -> StreamType = 0;
 
     /**
      * @return The number of events buffered.

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -2,6 +2,7 @@
 #define CLP_FFI_JS_IR_STREAMREADER_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <clp/ffi/ir_stream/decoding_methods.hpp>
@@ -17,6 +18,11 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(ReaderOptions);
 // JS types used as outputs
 EMSCRIPTEN_DECLARE_VAL_TYPE(DecodedResultsTsType);
 EMSCRIPTEN_DECLARE_VAL_TYPE(FilteredLogEventMapTsType);
+
+enum class IrStreamType : uint8_t {
+    Structured,
+    Unstructured,
+};
 
 /**
  * Class to deserialize and decode Zstandard-compressed CLP IR streams as well as format decoded
@@ -51,8 +57,7 @@ public:
     auto operator=(StreamReader&&) -> StreamReader& = delete;
 
     // Methods
-    [[nodiscard]] virtual auto get_ir_protocol_error_code(
-    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode = 0;
+    [[nodiscard]] virtual auto get_ir_stream_type() const -> IrStreamType = 0;
 
     /**
      * @return The number of events buffered.

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -37,8 +37,9 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(DataArrayTsType const& data_array,
-                                     ReaderOptions const& reader_options
+    [[nodiscard]] static auto create(
+            DataArrayTsType const& data_array,
+            ReaderOptions const& reader_options
     ) -> std::unique_ptr<StreamReader>;
 
     // Destructor

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -48,6 +48,7 @@ public:
      * @return A reference to the reader.
      */
     [[nodiscard]] auto get_reader() -> clp::ReaderInterface& { return *m_reader; }
+
 private:
     clp::Array<char> m_data_buffer;
     std::unique_ptr<clp::ReaderInterface> m_reader;

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -44,6 +44,10 @@ public:
      */
     [[nodiscard]] auto get_deserializer() -> Deserializer& { return m_deserializer; }
 
+    /**
+     * @return A reference to the reader.
+     */
+    [[nodiscard]] auto get_reader() -> clp::ReaderInterface& { return *m_reader; }
 private:
     clp::Array<char> m_data_buffer;
     std::unique_ptr<clp::ReaderInterface> m_reader;

--- a/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
+++ b/src/clp_ffi_js/ir/StreamReaderDataContext.hpp
@@ -39,14 +39,8 @@ public:
     ~StreamReaderDataContext() = default;
 
     // Methods
-    /**
-     * @return A reference to the deserializer.
-     */
     [[nodiscard]] auto get_deserializer() -> Deserializer& { return m_deserializer; }
 
-    /**
-     * @return A reference to the reader.
-     */
     [[nodiscard]] auto get_reader() -> clp::ReaderInterface& { return *m_reader; }
 
 private:

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -59,12 +59,12 @@ auto StructuredIrStreamReader::create(
                 )
         };
     }
-    auto data_context = StreamReaderDataContext<StructuredIrDeserializer>(
+    StreamReaderDataContext<StructuredIrDeserializer> data_context{
             std::move(data_array),
             std::move(zstd_decompressor),
             std::move(result.value())
-    );
-    return StructuredIrStreamReader(std::move(data_context), std::move(deserialized_log_events));
+    };
+    return StructuredIrStreamReader{std::move(data_context), std::move(deserialized_log_events)};
 }
 
 auto StructuredIrStreamReader::get_num_events_buffered() const -> size_t {

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -138,9 +138,6 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         return DecodedResultsTsType{emscripten::val::null()};
     }
 
-    std::string message;
-    constexpr size_t cDefaultReservedMessageLength{512};
-    message.reserve(cDefaultReservedMessageLength);
     auto const results{emscripten::val::array()};
 
     for (size_t log_event_idx = begin_idx; log_event_idx < end_idx; ++log_event_idx) {

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -155,19 +155,22 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         }
 
         auto const& id_value_pairs{log_event.get_node_id_value_pairs()};
-        clp::ffi::value_int_t log_level{static_cast<clp::ffi::value_int_t>(LogLevel::NONE)};
+        LogLevel log_level{LogLevel::NONE};
         if (m_level_node_id.has_value()) {
             auto const& log_level_pair{id_value_pairs.at(m_level_node_id.value())};
             log_level = log_level_pair.has_value()
-                                ? log_level_pair.value().get_immutable_view<clp::ffi::value_int_t>()
-                                : static_cast<clp::ffi::value_int_t>(LogLevel::NONE);
+                                ? static_cast<LogLevel>(
+                                          log_level_pair.value()
+                                                  .get_immutable_view<clp::ffi::value_int_t>()
+                                  )
+                                : log_level;
         }
         clp::ffi::value_int_t timestamp{0};
         if (m_timestamp_node_id.has_value()) {
             auto const& timestamp_pair{id_value_pairs.at(m_timestamp_node_id.value())};
             timestamp = timestamp_pair.has_value()
                                 ? timestamp_pair.value().get_immutable_view<clp::ffi::value_int_t>()
-                                : 0;
+                                : timestamp;
         }
 
         EM_ASM(

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -28,7 +28,7 @@
 namespace clp_ffi_js::ir {
 using clp::ir::four_byte_encoded_variable_t;
 
-static constexpr std::string_view cLogLevelFilteringNotSupportedPrompt{
+static constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
         "Log level filtering is not yet supported in this reader."
 };
 
@@ -72,7 +72,7 @@ auto StructuredIrStreamReader::get_num_events_buffered() const -> size_t {
 }
 
 auto StructuredIrStreamReader::get_filtered_log_event_map() const -> FilteredLogEventMapTsType {
-    SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+    SPDLOG_ERROR(cLogLevelFilteringNotSupportedErrorMsg);
     return FilteredLogEventMapTsType{emscripten::val::null()};
 }
 
@@ -80,7 +80,7 @@ void StructuredIrStreamReader::filter_log_events(LogLevelFilterTsType const& log
     if (log_level_filter.isNull()) {
         return;
     }
-    SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+    SPDLOG_ERROR(cLogLevelFilteringNotSupportedErrorMsg);
 }
 
 auto StructuredIrStreamReader::deserialize_stream() -> size_t {
@@ -130,7 +130,7 @@ auto StructuredIrStreamReader::deserialize_stream() -> size_t {
 auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
         -> DecodedResultsTsType {
     if (use_filter) {
-        SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+        SPDLOG_ERROR(cLogLevelFilteringNotSupportedErrorMsg);
         return DecodedResultsTsType{emscripten::val::null()};
     }
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -177,8 +177,8 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
                 { Emval.toValue($0).push([UTF8ToString($1), $2, $3, $4]); },
                 results.as_handle(),
                 json.value().dump().c_str(),
-                log_level,
                 timestamp,
+                log_level,
                 log_event_idx + 1
         );
     }

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -44,8 +44,8 @@ auto StructuredIrStreamReader::create(
             *zstd_decompressor,
             IrUnitHandler{
                     deserialized_log_events,
-                    reader_options[cReaderOptionsLogLevelKey].as<std::string>(),
-                    reader_options[cReaderOptionsTimestampKey].as<std::string>()
+                    reader_options[cReaderOptionsLogLevelKey.data()].as<std::string>(),
+                    reader_options[cReaderOptionsTimestampKey.data()].as<std::string>()
             }
     )};
     if (result.has_error()) {

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -187,9 +187,9 @@ StructuredIrStreamReader::StructuredIrStreamReader(
         StreamReaderDataContext<StructuredIrDeserializer>&& stream_reader_data_context,
         std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> deserialized_log_events
 )
-        : m_stream_reader_data_context{std::make_unique<
+        : m_deserialized_log_events{std::move(deserialized_log_events)},
+          m_stream_reader_data_context{std::make_unique<
                   StreamReaderDataContext<StructuredIrDeserializer>>(
                   std::move(stream_reader_data_context)
-          )},
-          m_deserialized_log_events{std::move(deserialized_log_events)} {}
+          )} {}
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -164,7 +164,7 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
                 if (timestamp_pair->is<clp::ffi::value_int_t>()) {
                     timestamp = timestamp_pair.value().get_immutable_view<clp::ffi::value_int_t>();
                 } else {
-                    // TODO: add support for parsing timestamp values of string type.
+                    // TODO: Add support for parsing timestamp values of string type.
                     SPDLOG_ERROR("Unable to parse timestamp for log_event_idx={}", log_event_idx);
                 }
             }

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -25,6 +25,7 @@
 #include <clp_ffi_js/ir/StreamReader.hpp>
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
+namespace clp_ffi_js::ir {
 namespace {
 constexpr std::string_view cEmptyJsonStr{"{}"};
 constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
@@ -33,7 +34,6 @@ constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
 constexpr std::string_view cReaderOptionsTimestampKey{"timestampKey"};
 }  // namespace
 
-namespace clp_ffi_js::ir {
 using clp::ir::four_byte_encoded_variable_t;
 
 auto StructuredIrStreamReader::create(

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -28,6 +28,7 @@
 namespace clp_ffi_js::ir {
 using clp::ir::four_byte_encoded_variable_t;
 
+static constexpr std::string_view cEmptyJsonStr{"{}"};
 static constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
         "Log level filtering is not yet supported in this reader."
 };
@@ -141,9 +142,11 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         auto const& log_event{m_deserialized_log_events->at(log_event_idx)};
 
         auto const json_result{log_event.serialize_to_json()};
+        std::string json_str{cEmptyJsonStr};
         if (false == json_result.has_value()) {
             SPDLOG_ERROR("Failed to decode log event.");
-            break;
+        } else {
+            json_str = json_result.value().dump();
         }
 
         auto const& id_value_pairs{log_event.get_node_id_value_pairs()};
@@ -163,7 +166,7 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         EM_ASM(
                 { Emval.toValue($0).push([UTF8ToString($1), $2, $3, $4]); },
                 results.as_handle(),
-                json_result.value().dump().c_str(),
+                json_str.c_str(),
                 timestamp,
                 LogLevel::NONE,
                 log_event_idx + 1

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -101,7 +101,7 @@ auto StructuredIrStreamReader::deserialize_stream() -> size_t {
             continue;
         }
         auto const error{result.error()};
-        if (std::errc::no_message_available == error || std::errc::operation_not_permitted == error)
+        if (std::errc::operation_not_permitted == error)
         {
             break;
         }

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -30,7 +30,7 @@ namespace clp_ffi_js::ir {
 using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 
-constexpr std::string_view cLogLevelFilteringNotSupportedPrompt{
+static constexpr std::string_view cLogLevelFilteringNotSupportedPrompt{
         "Log level filtering is not yet supported in this reader."
 };
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -101,8 +101,7 @@ auto StructuredIrStreamReader::deserialize_stream() -> size_t {
             continue;
         }
         auto const error{result.error()};
-        if (std::errc::operation_not_permitted == error)
-        {
+        if (std::errc::operation_not_permitted == error) {
             break;
         }
         if (std::errc::result_out_of_range == error) {

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -145,8 +145,8 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
     for (size_t log_event_idx = begin_idx; log_event_idx < end_idx; ++log_event_idx) {
         auto const& log_event{m_deserialized_log_events->at(log_event_idx)};
 
-        auto const json{log_event.serialize_to_json()};
-        if (false == json.has_value()) {
+        auto const json_result{log_event.serialize_to_json()};
+        if (false == json_result.has_value()) {
             SPDLOG_ERROR("Failed to decode log event.");
             break;
         }
@@ -173,7 +173,7 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         EM_ASM(
                 { Emval.toValue($0).push([UTF8ToString($1), $2, $3, $4]); },
                 results.as_handle(),
-                json.value().dump().c_str(),
+                json_result.value().dump().c_str(),
                 timestamp,
                 log_level,
                 log_event_idx + 1

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -111,7 +111,7 @@ auto StructuredIrStreamReader::deserialize_stream() -> size_t {
                 __FILENAME__,
                 __LINE__,
                 std::format(
-                        "Failed to deserialize: {}:{}",
+                        "Failed to deserialize IR unit: {}:{}",
                         error.category().name(),
                         error.message()
                 )
@@ -148,7 +148,7 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
 
         auto const json{log_event.serialize_to_json()};
         if (false == json.has_value()) {
-            SPDLOG_ERROR("Failed to decode message.");
+            SPDLOG_ERROR("Failed to decode log event.");
             break;
         }
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -121,7 +121,7 @@ auto StructuredIrStreamReader::deserialize_stream() -> size_t {
     }
     m_level_node_id = m_stream_reader_data_context->get_deserializer()
                               .get_ir_unit_handler()
-                              .get_level_node_id();
+                              .get_log_level_node_id();
     m_timestamp_node_id = m_stream_reader_data_context->get_deserializer()
                                   .get_ir_unit_handler()
                                   .get_timestamp_node_id();

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -25,14 +25,16 @@
 #include <clp_ffi_js/ir/StreamReader.hpp>
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
-namespace clp_ffi_js::ir {
-using clp::ir::four_byte_encoded_variable_t;
-
-static constexpr std::string_view cEmptyJsonStr{"{}"};
-static constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
+namespace {
+constexpr std::string_view cEmptyJsonStr{"{}"};
+constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
         "Log level filtering is not yet supported in this reader."
 };
-static constexpr std::string_view cReaderOptionsTimestampKey{"timestampKey"};
+constexpr std::string_view cReaderOptionsTimestampKey{"timestampKey"};
+}  // namespace
+
+namespace clp_ffi_js::ir {
+using clp::ir::four_byte_encoded_variable_t;
 
 auto StructuredIrStreamReader::create(
         std::unique_ptr<ZstdDecompressor>&& zstd_decompressor,

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -181,8 +181,9 @@ StructuredIrStreamReader::StructuredIrStreamReader(
         std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> deserialized_log_events
 )
         : m_deserialized_log_events{std::move(deserialized_log_events)},
-          m_stream_reader_data_context{std::make_unique<
-                  StreamReaderDataContext<StructuredIrDeserializer>>(
-                  std::move(stream_reader_data_context)
-          )} {}
+          m_stream_reader_data_context{
+                  std::make_unique<StreamReaderDataContext<StructuredIrDeserializer>>(
+                          std::move(stream_reader_data_context)
+                  )
+          } {}
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -146,7 +146,12 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         auto const json_result{log_event.serialize_to_json()};
         std::string json_str{cEmptyJsonStr};
         if (false == json_result.has_value()) {
-            SPDLOG_ERROR("Failed to decode log event.");
+            auto error_code{json_result.error()};
+            SPDLOG_ERROR(
+                    "Failed to deserialize log event to JSON: {}:{}",
+                    error_code.category().name(),
+                    error_code.message()
+            );
         } else {
             json_str = json_result.value().dump();
         }

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -1,0 +1,195 @@
+#include "StructuredIrStreamReader.hpp"
+
+#include <cstddef>
+#include <format>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <clp/Array.hpp>
+#include <clp/ErrorCode.hpp>
+#include <clp/ffi/ir_stream/Deserializer.hpp>
+#include <clp/ffi/KeyValuePairLogEvent.hpp>
+#include <clp/ffi/Value.hpp>
+#include <clp/ir/types.hpp>
+#include <clp/TraceableException.hpp>
+#include <emscripten/em_asm.h>
+#include <emscripten/val.h>
+#include <spdlog/spdlog.h>
+
+#include <clp_ffi_js/ClpFfiJsException.hpp>
+#include <clp_ffi_js/constants.hpp>
+#include <clp_ffi_js/ir/StreamReader.hpp>
+#include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
+
+namespace clp_ffi_js::ir {
+
+using namespace std::literals::string_literals;
+using clp::ir::four_byte_encoded_variable_t;
+
+constexpr std::string_view cLogLevelFilteringNotSupportedPrompt{
+        "Log level filtering is not yet supported in this reader."
+};
+
+auto StructuredIrStreamReader::create(
+        std::unique_ptr<ZstdDecompressor>&& zstd_decompressor,
+        clp::Array<char> data_array,
+        ReaderOptions const& reader_options
+) -> StructuredIrStreamReader {
+    auto deserialized_log_events{std::make_shared<std::vector<clp::ffi::KeyValuePairLogEvent>>()};
+    auto result{StructuredIrDeserializer::create(
+            *zstd_decompressor,
+            IrUnitHandler(
+                    deserialized_log_events,
+                    reader_options["logLevelKey"].as<std::string>(),
+                    reader_options["timestampKey"].as<std::string>()
+            )
+    )};
+    if (result.has_error()) {
+        auto const error_code{result.error()};
+        throw ClpFfiJsException{
+                clp::ErrorCode::ErrorCode_Failure,
+                __FILENAME__,
+                __LINE__,
+                std::format(
+                        "Failed to create deserializer: {} {}",
+                        error_code.category().name(),
+                        error_code.message()
+                )
+        };
+    }
+    auto data_context = StreamReaderDataContext<StructuredIrDeserializer>(
+            std::move(data_array),
+            std::move(zstd_decompressor),
+            std::move(result.value())
+    );
+    return StructuredIrStreamReader(std::move(data_context), std::move(deserialized_log_events));
+}
+
+auto StructuredIrStreamReader::get_num_events_buffered() const -> size_t {
+    return m_deserialized_log_events->size();
+}
+
+auto StructuredIrStreamReader::get_filtered_log_event_map() const -> FilteredLogEventMapTsType {
+    SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+    return FilteredLogEventMapTsType{emscripten::val::null()};
+}
+
+void StructuredIrStreamReader::filter_log_events(LogLevelFilterTsType const& log_level_filter) {
+    if (log_level_filter.isNull()) {
+        return;
+    }
+    SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+}
+
+auto StructuredIrStreamReader::deserialize_stream() -> size_t {
+    if (nullptr == m_stream_reader_data_context) {
+        return m_deserialized_log_events->size();
+    }
+
+    constexpr size_t cDefaultNumReservedLogEvents{500'000};
+    m_deserialized_log_events->reserve(cDefaultNumReservedLogEvents);
+    auto& reader{m_stream_reader_data_context->get_reader()};
+    while (true) {
+        auto result{m_stream_reader_data_context->get_deserializer().deserialize_next_ir_unit(reader
+        )};
+        if (false == result.has_error()) {
+            continue;
+        }
+        auto const error{result.error()};
+        if (std::errc::no_message_available == error || std::errc::operation_not_permitted == error)
+        {
+            break;
+        }
+        if (std::errc::result_out_of_range == error) {
+            SPDLOG_ERROR("File contains an incomplete IR stream");
+            break;
+        }
+        throw ClpFfiJsException{
+                clp::ErrorCode::ErrorCode_Corrupt,
+                __FILENAME__,
+                __LINE__,
+                std::format(
+                        "Failed to deserialize: {}:{}",
+                        error.category().name(),
+                        error.message()
+                )
+        };
+    }
+    m_level_node_id = m_stream_reader_data_context->get_deserializer()
+                              .get_ir_unit_handler()
+                              .get_level_node_id();
+    m_timestamp_node_id = m_stream_reader_data_context->get_deserializer()
+                                  .get_ir_unit_handler()
+                                  .get_timestamp_node_id();
+    m_stream_reader_data_context.reset(nullptr);
+    return m_deserialized_log_events->size();
+}
+
+auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
+        -> DecodedResultsTsType {
+    if (use_filter) {
+        SPDLOG_ERROR(cLogLevelFilteringNotSupportedPrompt);
+        return DecodedResultsTsType{emscripten::val::null()};
+    }
+
+    if (m_deserialized_log_events->size() < end_idx || begin_idx > end_idx) {
+        return DecodedResultsTsType{emscripten::val::null()};
+    }
+
+    std::string message;
+    constexpr size_t cDefaultReservedMessageLength{512};
+    message.reserve(cDefaultReservedMessageLength);
+    auto const results{emscripten::val::array()};
+
+    for (size_t log_event_idx = begin_idx; log_event_idx < end_idx; ++log_event_idx) {
+        auto const& log_event{m_deserialized_log_events->at(log_event_idx)};
+
+        auto const json{log_event.serialize_to_json()};
+        if (false == json.has_value()) {
+            SPDLOG_ERROR("Failed to decode message.");
+            break;
+        }
+
+        auto const& id_value_pairs{log_event.get_node_id_value_pairs()};
+        clp::ffi::value_int_t log_level{static_cast<clp::ffi::value_int_t>(LogLevel::NONE)};
+        if (m_level_node_id.has_value()) {
+            auto const& log_level_pair{id_value_pairs.at(m_level_node_id.value())};
+            log_level = log_level_pair.has_value()
+                                ? log_level_pair.value().get_immutable_view<clp::ffi::value_int_t>()
+                                : static_cast<clp::ffi::value_int_t>(LogLevel::NONE);
+        }
+        clp::ffi::value_int_t timestamp{0};
+        if (m_timestamp_node_id.has_value()) {
+            auto const& timestamp_pair{id_value_pairs.at(m_timestamp_node_id.value())};
+            timestamp = timestamp_pair.has_value()
+                                ? timestamp_pair.value().get_immutable_view<clp::ffi::value_int_t>()
+                                : 0;
+        }
+
+        EM_ASM(
+                { Emval.toValue($0).push([UTF8ToString($1), $2, $3, $4]); },
+                results.as_handle(),
+                json.value().dump().c_str(),
+                log_level,
+                timestamp,
+                log_event_idx + 1
+        );
+    }
+
+    return DecodedResultsTsType(results);
+}
+
+StructuredIrStreamReader::StructuredIrStreamReader(
+        StreamReaderDataContext<StructuredIrDeserializer>&& stream_reader_data_context,
+        std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> deserialized_log_events
+)
+        : m_stream_reader_data_context{std::make_unique<
+                  StreamReaderDataContext<StructuredIrDeserializer>>(
+                  std::move(stream_reader_data_context)
+          )},
+          m_deserialized_log_events{std::move(deserialized_log_events)} {}
+}  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -40,11 +40,11 @@ auto StructuredIrStreamReader::create(
     auto deserialized_log_events{std::make_shared<std::vector<clp::ffi::KeyValuePairLogEvent>>()};
     auto result{StructuredIrDeserializer::create(
             *zstd_decompressor,
-            IrUnitHandler(
+            IrUnitHandler{
                     deserialized_log_events,
                     reader_options["logLevelKey"].as<std::string>(),
                     reader_options["timestampKey"].as<std::string>()
-            )
+            }
     )};
     if (result.has_error()) {
         auto const error_code{result.error()};

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -26,8 +26,6 @@
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
 namespace clp_ffi_js::ir {
-
-using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 
 static constexpr std::string_view cLogLevelFilteringNotSupportedPrompt{

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -31,6 +31,8 @@ using clp::ir::four_byte_encoded_variable_t;
 static constexpr std::string_view cLogLevelFilteringNotSupportedErrorMsg{
         "Log level filtering is not yet supported in this reader."
 };
+static constexpr std::string_view cReaderOptionsLogLevelKey{"logLevelKey"};
+static constexpr std::string_view cReaderOptionsTimestampKey{"timestampKey"};
 
 auto StructuredIrStreamReader::create(
         std::unique_ptr<ZstdDecompressor>&& zstd_decompressor,
@@ -42,8 +44,8 @@ auto StructuredIrStreamReader::create(
             *zstd_decompressor,
             IrUnitHandler{
                     deserialized_log_events,
-                    reader_options["logLevelKey"].as<std::string>(),
-                    reader_options["timestampKey"].as<std::string>()
+                    reader_options[cReaderOptionsLogLevelKey].as<std::string>(),
+                    reader_options[cReaderOptionsTimestampKey].as<std::string>()
             }
     )};
     if (result.has_error()) {

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -150,9 +150,14 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
         clp::ffi::value_int_t timestamp{0};
         if (m_timestamp_node_id.has_value()) {
             auto const& timestamp_pair{id_value_pairs.at(m_timestamp_node_id.value())};
-            timestamp = timestamp_pair.has_value()
-                                ? timestamp_pair.value().get_immutable_view<clp::ffi::value_int_t>()
-                                : timestamp;
+            if (timestamp_pair.has_value()) {
+                if (timestamp_pair->is<clp::ffi::value_int_t>()) {
+                    timestamp = timestamp_pair.value().get_immutable_view<clp::ffi::value_int_t>();
+                } else {
+                    // TODO: add support for parsing timestamp values of string type.
+                    SPDLOG_ERROR("Unable to parse timestamp for log_event_idx={}", log_event_idx);
+                }
+            }
         }
 
         EM_ASM(

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -158,6 +158,11 @@ public:
             ReaderOptions const& reader_options
     ) -> StructuredIrStreamReader;
 
+    [[nodiscard]] auto get_ir_protocol_error_code(
+    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode override {
+        return clp::ffi::ir_stream::IRProtocolErrorCode::Supported;
+    }
+
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;
 
     [[nodiscard]] auto get_filtered_log_event_map() const -> FilteredLogEventMapTsType override;

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -78,7 +78,7 @@ public:
      * @return IRErrorCode::IRErrorCode_Success
      */
     [[nodiscard]] auto handle_schema_tree_node_insertion(
-            [[maybe_unused]] clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
+            clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
     ) -> clp::ffi::ir_stream::IRErrorCode {
         ++m_current_node_id;
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -125,6 +125,10 @@ private:
 
     parsed_tree_node_id_t m_level_node_id;
     parsed_tree_node_id_t m_timestamp_node_id;
+
+    // TODO: Technically, we don't need to use a `shared_ptr` since the parent stream reader will
+    // have a longer lifetime than this class. Instead, we could use `gsl::not_null` once we add
+    // `gsl` into the project.
     std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> m_deserialized_log_events;
 };
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -66,7 +66,7 @@ public:
             [[maybe_unused]] clp::UtcOffset utc_offset_old,
             [[maybe_unused]] clp::UtcOffset utc_offset_new
     ) -> clp::ffi::ir_stream::IRErrorCode {
-        SPDLOG_WARN("UTC offset change packets are currently not handled.");
+        SPDLOG_WARN("UTC offset change packets aren't handled currently.");
 
         return clp::ffi::ir_stream::IRErrorCode::IRErrorCode_Success;
     }

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -1,19 +1,19 @@
 #ifndef CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
 #define CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
 
-#include <clp/Array.hpp>
 #include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
-#include <clp/time_types.hpp>
 #include <utility>
 #include <vector>
 
+#include <clp/Array.hpp>
 #include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ffi/ir_stream/Deserializer.hpp>
 #include <clp/ffi/KeyValuePairLogEvent.hpp>
 #include <clp/ffi/SchemaTree.hpp>
+#include <clp/time_types.hpp>
 #include <emscripten/val.h>
 #include <spdlog/spdlog.h>
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -85,7 +85,7 @@ public:
 
         auto const& key_name{schema_tree_node_locator.get_key_name()};
         if (m_log_level_key == key_name) {
-            m_level_node_id.emplace(m_current_node_id);
+            m_log_level_node_id.emplace(m_current_node_id);
         } else if (m_timestamp_key == key_name) {
             m_timestamp_node_id.emplace(m_current_node_id);
         }
@@ -104,8 +104,8 @@ public:
     /**
      * @return The schema-tree node ID associated with events' authoritative log-level key.
      */
-    [[nodiscard]] auto get_level_node_id() const -> schema_tree_node_id_t {
-        return m_level_node_id;
+    [[nodiscard]] auto get_log_level_node_id() const -> schema_tree_node_id_t {
+        return m_log_level_node_id;
     }
 
     /**
@@ -122,7 +122,7 @@ private:
 
     clp::ffi::SchemaTree::Node::id_t m_current_node_id{clp::ffi::SchemaTree::cRootId};
 
-    schema_tree_node_id_t m_level_node_id;
+    schema_tree_node_id_t m_log_level_node_id;
     schema_tree_node_id_t m_timestamp_node_id;
 
     // TODO: Technically, we don't need to use a `shared_ptr` since the parent stream reader will

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -139,18 +139,6 @@ using StructuredIrDeserializer = clp::ffi::ir_stream::Deserializer<IrUnitHandler
  */
 class StructuredIrStreamReader : public StreamReader {
 public:
-    // Destructor
-    ~StructuredIrStreamReader() override = default;
-
-    // Disable copy constructor and assignment operator
-    StructuredIrStreamReader(StructuredIrStreamReader const&) = delete;
-    auto operator=(StructuredIrStreamReader const&) -> StructuredIrStreamReader& = delete;
-
-    // Define default move constructor
-    StructuredIrStreamReader(StructuredIrStreamReader&&) = default;
-    // Delete move assignment operator since it's also disabled in `clp::ir::LogEventDeserializer`.
-    auto operator=(StructuredIrStreamReader&&) -> StructuredIrStreamReader& = delete;
-
     /**
      * @param zstd_decompressor A decompressor for an IR stream, where the read head of the stream
      * is just after the stream's encoding type.
@@ -164,6 +152,18 @@ public:
             clp::Array<char> data_array,
             ReaderOptions const& reader_options
     ) -> StructuredIrStreamReader;
+
+    // Destructor
+    ~StructuredIrStreamReader() override = default;
+
+    // Disable copy constructor and assignment operator
+    StructuredIrStreamReader(StructuredIrStreamReader const&) = delete;
+    auto operator=(StructuredIrStreamReader const&) -> StructuredIrStreamReader& = delete;
+
+    // Define default move constructor
+    StructuredIrStreamReader(StructuredIrStreamReader&&) = default;
+    // Delete move assignment operator since it's also disabled in `clp::ir::LogEventDeserializer`.
+    auto operator=(StructuredIrStreamReader&&) -> StructuredIrStreamReader& = delete;
 
     [[nodiscard]] auto get_ir_stream_type() const -> IrStreamType override {
         return IrStreamType::Structured;

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -3,9 +3,7 @@
 
 #include <Array.hpp>
 #include <cstddef>
-#include <ffi/ir_stream/decoding_methods.hpp>
-#include <ffi/KeyValuePairLogEvent.hpp>
-#include <ffi/SchemaTree.hpp>
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -13,7 +11,10 @@
 #include <utility>
 #include <vector>
 
+#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ffi/ir_stream/Deserializer.hpp>
+#include <clp/ffi/KeyValuePairLogEvent.hpp>
+#include <clp/ffi/SchemaTree.hpp>
 #include <emscripten/val.h>
 #include <spdlog/spdlog.h>
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -3,7 +3,6 @@
 
 #include <clp/Array.hpp>
 #include <cstddef>
-
 #include <memory>
 #include <optional>
 #include <string>
@@ -166,9 +165,8 @@ public:
             ReaderOptions const& reader_options
     ) -> StructuredIrStreamReader;
 
-    [[nodiscard]] auto get_ir_protocol_error_code(
-    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode override {
-        return clp::ffi::ir_stream::IRProtocolErrorCode::Supported;
+    [[nodiscard]] auto get_ir_stream_type() const -> IrStreamType override {
+        return IrStreamType::Structured;
     }
 
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -149,8 +149,8 @@ public:
     // Delete move assignment operator since it's also disabled in `clp::ir::LogEventDeserializer`.
     auto operator=(StructuredIrStreamReader&&) -> StructuredIrStreamReader& = delete;
 
-    [[nodiscard]] auto get_ir_stream_type() const -> IrStreamType override {
-        return IrStreamType::Structured;
+    [[nodiscard]] auto get_ir_stream_type() const -> StreamType override {
+        return StreamType::Structured;
     }
 
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -1,0 +1,169 @@
+#ifndef CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
+#define CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
+
+#include <Array.hpp>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <clp/ffi/ir_stream/Deserializer.hpp>
+#include <clp/ir/LogEventDeserializer.hpp>
+#include <clp/ir/types.hpp>
+#include <clp/TimestampPattern.hpp>
+#include <emscripten/val.h>
+#include <spdlog/spdlog.h>
+
+#include <clp_ffi_js/ir/LogEventWithLevel.hpp>
+#include <clp_ffi_js/ir/StreamReader.hpp>
+#include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
+
+namespace clp_ffi_js::ir {
+using parsed_tree_node_id_t = std::optional<clp::ffi::SchemaTree::Node::id_t>;
+
+/**
+ * Class to handle deserialized IR units.
+ */
+class IrUnitHandler {
+public:
+    IrUnitHandler(
+            std::vector<clp::ffi::KeyValuePairLogEvent>& deserialized_log_events,
+            std::string log_level_key,
+            std::string timestamp_key
+    )
+            : m_deserialized_log_events{deserialized_log_events},
+              m_log_level_key{std::move(log_level_key)},
+              m_timestamp_key{std::move(timestamp_key)} {}
+
+    // Implements `clp::ffi::ir_stream::IrUnitHandlerInterface` interface
+    [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event
+    ) -> clp::ffi::ir_stream::IRErrorCode {
+        m_deserialized_log_events.emplace_back(std::move(log_event));
+
+        return clp::ffi::ir_stream::IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] static auto handle_utc_offset_change(
+            [[maybe_unused]] clp::UtcOffset utc_offset_old,
+            [[maybe_unused]] clp::UtcOffset utc_offset_new
+    ) -> clp::ffi::ir_stream::IRErrorCode {
+        SPDLOG_WARN("UTC offset change packets are currently not handled.");
+
+        return clp::ffi::ir_stream::IRErrorCode::IRErrorCode_Success;
+    }
+
+    [[nodiscard]] auto handle_schema_tree_node_insertion(
+            [[maybe_unused]] clp::ffi::SchemaTree::NodeLocator schema_tree_node_locator
+    ) -> clp::ffi::ir_stream::IRErrorCode {
+        ++m_current_node_id;
+        auto const& key_name{schema_tree_node_locator.get_key_name()};
+
+        if (m_log_level_key == key_name) {
+            m_level_node_id.emplace(m_current_node_id);
+        } else if (m_timestamp_key == key_name) {
+            m_timestamp_node_id.emplace(m_current_node_id);
+        }
+
+        return clp::ffi::ir_stream::IRErrorCode::IRErrorCode_Success;
+    }
+
+    // FIXME: do i need this?
+    [[nodiscard]] static auto handle_end_of_stream() -> clp::ffi::ir_stream::IRErrorCode {
+        return clp::ffi::ir_stream::IRErrorCode::IRErrorCode_Success;
+    }
+
+    // Methods
+    [[nodiscard]] auto get_deserialized_log_events(
+    ) const -> std::vector<clp::ffi::KeyValuePairLogEvent> const& {
+        return m_deserialized_log_events;
+    }
+
+    [[nodiscard]] auto get_level_node_id() const -> parsed_tree_node_id_t {
+        return m_level_node_id;
+    }
+
+    [[nodiscard]] auto get_timestamp_node_id() const -> parsed_tree_node_id_t {
+        return m_timestamp_node_id;
+    }
+
+private:
+    std::string m_log_level_key;
+    std::string m_timestamp_key;
+
+    // the root node has id=0
+    clp::ffi::SchemaTree::Node::id_t m_current_node_id;
+    parsed_tree_node_id_t m_level_node_id;
+    parsed_tree_node_id_t m_timestamp_node_id;
+
+    std::vector<clp::ffi::KeyValuePairLogEvent>& m_deserialized_log_events;
+    bool m_is_complete{false};
+};
+
+using StructuredIrDeserializer = clp::ffi::ir_stream::Deserializer<IrUnitHandler>;
+
+/**
+ * Class to deserialize and decode Zstd-compressed CLP structured IR streams, as well as format
+ * decoded log events.
+ */
+class StructuredIrStreamReader : public StreamReader {
+public:
+    // Destructor
+    ~StructuredIrStreamReader() override = default;
+
+    // Disable copy constructor and assignment operator
+    StructuredIrStreamReader(StructuredIrStreamReader const&) = delete;
+    auto operator=(StructuredIrStreamReader const&) -> StructuredIrStreamReader& = delete;
+
+    // Define default move constructor
+    StructuredIrStreamReader(StructuredIrStreamReader&&) = default;
+    // Delete move assignment operator since it's also disabled in `clp::ir::LogEventDeserializer`.
+    auto operator=(StructuredIrStreamReader&&) -> StructuredIrStreamReader& = delete;
+
+    /**
+     * @param zstd_decompressor A decompressor for an IR stream, where the read head of the stream
+     * is just after the stream's encoding type.
+     * @param data_array The array backing `zstd_decompressor`.
+     * @return The created instance.
+     * @throw ClpFfiJsException if any error occurs.
+     */
+    [[nodiscard]] static auto create(
+            std::unique_ptr<ZstdDecompressor>&& zstd_decompressor,
+            clp::Array<char> data_array,
+            ReaderOptions const& reader_options
+    ) -> StructuredIrStreamReader;
+
+    [[nodiscard]] auto get_num_events_buffered() const -> size_t override;
+
+    [[nodiscard]] auto get_filtered_log_event_map() const -> FilteredLogEventMapTsType override;
+
+    void filter_log_events(LogLevelFilterTsType const& log_level_filter) override;
+
+    /**
+     * @see StreamReader::deserialize_stream
+     *
+     * After the stream has been exhausted, it will be deallocated.
+     *
+     * @return @see StreamReader::deserialize_stream
+     */
+    [[nodiscard]] auto deserialize_stream() -> size_t override;
+
+    [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
+            -> DecodedResultsTsType override;
+
+private:
+    // Constructor
+    explicit StructuredIrStreamReader(
+            StreamReaderDataContext<StructuredIrDeserializer>&& stream_reader_data_context,
+            std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> deserialized_log_events
+    );
+
+    // Variables
+    std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> m_deserialized_log_events;
+    std::unique_ptr<StreamReaderDataContext<StructuredIrDeserializer>> m_stream_reader_data_context;
+
+    parsed_tree_node_id_t m_level_node_id;
+    parsed_tree_node_id_t m_timestamp_node_id;
+};
+}  // namespace clp_ffi_js::ir
+
+#endif  // CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -21,7 +21,7 @@
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
 namespace clp_ffi_js::ir {
-using parsed_tree_node_id_t = std::optional<clp::ffi::SchemaTree::Node::id_t>;
+using schema_tree_node_id_t = std::optional<clp::ffi::SchemaTree::Node::id_t>;
 
 /**
  * Class that implements the `clp::ffi::ir_stream::IrUnitHandlerInterface` to buffer log events and
@@ -104,14 +104,14 @@ public:
     /**
      * @return The schema-tree node ID associated with events' authoritative log-level key.
      */
-    [[nodiscard]] auto get_level_node_id() const -> parsed_tree_node_id_t {
+    [[nodiscard]] auto get_level_node_id() const -> schema_tree_node_id_t {
         return m_level_node_id;
     }
 
     /**
      * @return The schema-tree node ID associated with events' authoritative timestamp key.
      */
-    [[nodiscard]] auto get_timestamp_node_id() const -> parsed_tree_node_id_t {
+    [[nodiscard]] auto get_timestamp_node_id() const -> schema_tree_node_id_t {
         return m_timestamp_node_id;
     }
 
@@ -122,8 +122,8 @@ private:
 
     clp::ffi::SchemaTree::Node::id_t m_current_node_id{clp::ffi::SchemaTree::cRootId};
 
-    parsed_tree_node_id_t m_level_node_id;
-    parsed_tree_node_id_t m_timestamp_node_id;
+    schema_tree_node_id_t m_level_node_id;
+    schema_tree_node_id_t m_timestamp_node_id;
 
     // TODO: Technically, we don't need to use a `shared_ptr` since the parent stream reader will
     // have a longer lifetime than this class. Instead, we could use `gsl::not_null` once we add
@@ -198,8 +198,8 @@ private:
     std::shared_ptr<std::vector<clp::ffi::KeyValuePairLogEvent>> m_deserialized_log_events;
     std::unique_ptr<StreamReaderDataContext<StructuredIrDeserializer>> m_stream_reader_data_context;
 
-    parsed_tree_node_id_t m_level_node_id;
-    parsed_tree_node_id_t m_timestamp_node_id;
+    schema_tree_node_id_t m_level_node_id;
+    schema_tree_node_id_t m_timestamp_node_id;
 };
 }  // namespace clp_ffi_js::ir
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -1,13 +1,13 @@
 #ifndef CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
 #define CLP_FFI_JS_IR_STRUCTUREDIRSTREAMREADER_HPP
 
-#include <Array.hpp>
+#include <clp/Array.hpp>
 #include <cstddef>
 
 #include <memory>
 #include <optional>
 #include <string>
-#include <time_types.hpp>
+#include <clp/time_types.hpp>
 #include <utility>
 #include <vector>
 

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -41,9 +41,9 @@ public:
             std::string log_level_key,
             std::string timestamp_key
     )
-            : m_deserialized_log_events{std::move(deserialized_log_events)},
-              m_log_level_key{std::move(log_level_key)},
-              m_timestamp_key{std::move(timestamp_key)} {}
+            : m_log_level_key{std::move(log_level_key)},
+              m_timestamp_key{std::move(timestamp_key)},
+              m_deserialized_log_events{std::move(deserialized_log_events)} {}
 
     // Methods implementing `clp::ffi::ir_stream::IrUnitHandlerInterface`.
     /**

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <vector>
 
+#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ir/LogEventDeserializer.hpp>
 #include <clp/ir/types.hpp>
 #include <clp/TimestampPattern.hpp>

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -56,6 +56,11 @@ public:
             clp::Array<char> data_array
     ) -> UnstructuredIrStreamReader;
 
+    [[nodiscard]] auto get_ir_protocol_error_code(
+    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode override {
+        return clp::ffi::ir_stream::IRProtocolErrorCode::BackwardCompatible;
+    }
+
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;
 
     [[nodiscard]] auto get_filtered_log_event_map() const -> FilteredLogEventMapTsType override;

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -56,8 +56,8 @@ public:
             clp::Array<char> data_array
     ) -> UnstructuredIrStreamReader;
 
-    [[nodiscard]] auto get_ir_stream_type() const -> IrStreamType override {
-        return IrStreamType::Unstructured;
+    [[nodiscard]] auto get_ir_stream_type() const -> StreamType override {
+        return StreamType::Unstructured;
     }
 
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -7,7 +7,6 @@
 #include <optional>
 #include <vector>
 
-#include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ir/LogEventDeserializer.hpp>
 #include <clp/ir/types.hpp>
 #include <clp/TimestampPattern.hpp>
@@ -57,9 +56,8 @@ public:
             clp::Array<char> data_array
     ) -> UnstructuredIrStreamReader;
 
-    [[nodiscard]] auto get_ir_protocol_error_code(
-    ) const -> clp::ffi::ir_stream::IRProtocolErrorCode override {
-        return clp::ffi::ir_stream::IRProtocolErrorCode::BackwardCompatible;
+    [[nodiscard]] auto get_ir_stream_type() const -> IrStreamType override {
+        return IrStreamType::Unstructured;
     }
 
     [[nodiscard]] auto get_num_events_buffered() const -> size_t override;


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Add `StructuredIrStreamReader` which supports reading v0.1.0 IR streams without log level filtering.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Extracted and placed sample file at project root: [test-irv2.clp.zip](https://github.com/user-attachments/files/17658298/test-irv2.clp.zip)

2. Built the js assets with task and ran below sample code at project root:

    ```js
    import ModuleInit from "./cmake-build-debug/ClpFfiJs-node.js"
    import fs from "node:fs"
    
    const main = async () => {
        const file = fs.readFileSync("./test-irv2.clp.zst")
    
        console.time("perf")
        const Module = await ModuleInit()
        try {
            // const decoder = new Module.ClpStreamReader(new Uint8Array(file))
            const decoder = new Module.ClpStreamReader(new Uint8Array(file), {timestampKey: "timestamp"})
            console.log("type:", decoder.getIrStreamType() === Module.IrStreamType.STRUCTURED,
                decoder.getIrStreamType() === Module.IrStreamType.UNSTRUCTURED)
            const numEvents = decoder.deserializeStream()
            console.log(numEvents)
            const results = decoder.decodeRange(0, numEvents, false)
            console.log(results)
    
            decoder.filterLogEvents([0]) // Expect error printed
    
            const filteredLogEventMap = decoder.getFilteredLogEventMap() // Expect error printed
            console.log(filteredLogEventMap) // Expect: null
        } catch (e) {
            console.error("Exception caught:", e.stack)
        }
        console.timeEnd("perf")
    }
    
    void main()
    
    ```
2. Observed below in the console:
    ```ini
    [2024-11-07 03:19:49.407] [info] [StreamReader.cpp:162] StreamReader::create: got buffer of length=391
    [2024-11-07 03:19:49.425] [info] [StreamReader.cpp:112] IR version is 0.1.0
    type: true false
    1000
    [
      [
        '{"@timestamp":1730965799000,"application":{"nestedNodeKey":"nestedNodeVal"},"application_hashes":["3bbb624d",123,null,{"arrayNodeKey":"arrayNodeVal"},true],"count":-123.1,"is_contained":false,"log.level":1,"message":"hello","process.thread.name":"main","service":null}',
        0n,
        0,
        1
      ],
      [
        '{"@timestamp":1730965799000,"application":{"nestedNodeKey":"nestedNodeVal"},"application_hashes":["3bbb624d",123,null,{"arrayNodeKey":"arrayNodeVal"},true],"count":-123.1,"is_contained":false,"log.level":1,"message":"hello","process.thread.name":"main","service":null}',
        0n,
        0,
        2
      ],
      ...
      ... 900 more items
    ]
    [2024-11-07 03:19:49.696] [error] [StructuredIrStreamReader.cpp:85] Log level filtering is not yet supported in this reader.
    [2024-11-07 03:19:49.696] [error] [StructuredIrStreamReader.cpp:77] Log level filtering is not yet supported in this reader.
    null
    perf: 343.331ms
    ```
3. Sanitize-tested Zstd-compressed CLP IR stream files with older versions:
   1. test-0.0.1.clp.zst : Downloaded from https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst : succeeded.
   2. test-0.0.2.clp.zst : [test-0.0.2.clp.zip](https://github.com/user-attachments/files/17656891/test-0.0.2.clp.zip) : succeeded.
   3. An empty file: failed.
   4. A beta version file that is never supported on CLP OSS: failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced the `StructuredIrStreamReader` class for improved handling of structured IR streams.
	- Added flexible configuration options for the `StreamReader` class.
	- Enhanced error handling for stream deserialization.
	- New method `get_reader` in `StreamReaderDataContext` for accessing the reader interface.
	- Added a method to retrieve the IR stream type in the `UnstructuredIrStreamReader` class.

- **Bug Fixes**
	- Improved validation logic for IR stream versions.

- **Chores**
	- Updated submodule to the latest commit for enhanced functionality and stability.

These changes collectively enhance the project's capability to manage and process structured data streams effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->