### PR TITLE
Update `DecodedResultsTsType` to use `bigint` in Emscripten binding (fixes #33).

### DIFF
--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -124,7 +124,7 @@ EMSCRIPTEN_BINDINGS(ClpStreamReader) {
             .value("STRUCTURED", clp_ffi_js::ir::StreamType::Structured)
             .value("UNSTRUCTURED", clp_ffi_js::ir::StreamType::Unstructured);
     emscripten::register_type<clp_ffi_js::ir::DecodedResultsTsType>(
-            "Array<[string, number, number, number]>"
+            "Array<[string, bigint, number, number]>"
     );
     emscripten::register_type<clp_ffi_js::ir::FilteredLogEventMapTsType>("number[] | null");
     emscripten::class_<clp_ffi_js::ir::StreamReader>("ClpStreamReader")


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Update timestamp type declaration for `DecodedResultsTsType`.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Ran `task` to generate the compiled assets.
2. Validated in both `build/clp-ffi-js/ClpFfiJs-node.d.ts` and `build/clp-ffi-js/ClpFfiJs-woker.d.ts` that the return result of  `ClpStreamReader.decodeRange` has been updated as `Array<[string, bigint, number, number]>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling with updated numerical data representation.
	- Improved error handling for better feedback on processing issues.

- **Bug Fixes**
	- Refined error messages for specific IR error codes during processing.
	- Enhanced exception handling for JSON parsing failures.

- **Chores**
	- Added logging for buffer length to assist with debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->