### PR TITLE
feat(build): Set `MAXIMUM_MEMORY=4GB` in linker flags (fixes #25).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(CLP_FFI_JS_COMMON_LINK_OPTIONS
     -fwasm-exceptions
     -sALLOW_MEMORY_GROWTH
     -sEXPORT_ES6
+    -sMAXIMUM_MEMORY=4GB
     -sMODULARIZE
     -sWASM_BIGINT
 )


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

linting: Print line and column number of violation (fixes #999).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Set `MAXIMUM_MEMORY=4GB` in linker flags.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. With Node.js, ran perf test 3 times with a version `0.1.0` structured log stream file containing 4.5 million log event entries and observed no significant drop in time performance.
   1. With default 2GB max memory (before): 15.050s, 15.624s, 16.136s
   2. With 4GB max memory (with changes in this PR): 15.312s, 15.180s, 15.050s
   Test code:
    ```
    import ModuleInit from "./cmake-build-release/ClpFfiJs-node.js"
    import fs from "node:fs"
    
    const main = async () => {
        const file = fs.readFileSync("./test-4.5M.clp.zst")
    
        console.time("perf")
        const Module = await ModuleInit()
        try {
            const decoder = new Module.ClpStreamReader(new Uint8Array(file), {logLevelKey: "$log_level", timestampKey: "$timestamp"})
            console.log("type:", decoder.getIrStreamType() === Module.IrStreamType.STRUCTURED,
                decoder.getIrStreamType() === Module.IrStreamType.UNSTRUCTURED)
            const numEvents = decoder.deserializeStream()
            console.log(numEvents)
            const results = decoder.decodeRange(0, numEvents, false)
            console.log(results)
        } catch (e) {
            console.error("Exception caught:", e.stack)
        }
        console.timeEnd("perf")
    }
    
    void main()
    
    ```
2. Compared sizes before and after the change and found no signication increase in code size.
   1. ClpFfiJs-worker.d.ts: `1.23 KB (1,261 bytes)` -> `1.23 KB (1,261 bytes)` (unchanged).
   2. ClpFfiJs-worker.js: `25.8 KB (26,427 bytes)` -> `27.3 KB (28,007 bytes)` (5% increase).
   3. ClpFfiJs-worker.wasm: `742 KB (760,314 bytes)` -> `742 KB (760,314 bytes)` (unchanged).
