### PR TITLE
build(cmake): Extract CMake project name and version from package.json.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,11 @@ endif()
 
 # Extract the project name & version from package.json
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/package.json")
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.json" PACKAGE_JSON_CONTENT)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.json" CLP_FFI_JS_PACKAGE_JSON_CONTENT)
 else()
     message(FATAL_ERROR "`package.json` not found in ${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
-if("${PACKAGE_JSON_CONTENT}" MATCHES "\"name\":[ ]*\"([^\"]+)\"")
+if("${CLP_FFI_JS_PACKAGE_JSON_CONTENT}" MATCHES "\"name\":[ ]*\"([^\"]+)\"")
     set(CLP_FFI_JS_PROJECT_NAME
             "${CMAKE_MATCH_1}"
             CACHE STRING
@@ -25,7 +25,7 @@ if("${PACKAGE_JSON_CONTENT}" MATCHES "\"name\":[ ]*\"([^\"]+)\"")
 else()
     set(CLP_FFI_JS_PROJECT_NAME "clp-ffi-js" CACHE STRING "Use a placeholder project name." FORCE)
 endif()
-if("${PACKAGE_JSON_CONTENT}" MATCHES "\"version\":[ ]*\"([^\"]+)\"")
+if("${CLP_FFI_JS_PACKAGE_JSON_CONTENT}" MATCHES "\"version\":[ ]*\"([^\"]+)\"")
     set(CLP_FFI_JS_VERSION
         "${CMAKE_MATCH_1}"
         CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,35 @@ Emscripten.cmake"
     )
 endif()
 
+# Extract the project name & version from package.json
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.json" PACKAGE_JSON_CONTENT)
+if(${PACKAGE_JSON_CONTENT} MATCHES "\"name\":[ ]*\"([^\"]+)\"")
+    set(CLP_FFI_JS_PROJECT_NAME
+            ${CMAKE_MATCH_1}
+            CACHE STRING
+            "The name of the project parsed from `package.json`."
+            FORCE
+    )
+else()
+    set(CLP_FFI_JS_PROJECT_NAME "clp-ffi-js" CACHE STRING "Use a placeholder project name." FORCE)
+endif()
+if(${PACKAGE_JSON_CONTENT} MATCHES "\"version\":[ ]*\"([^\"]+)\"")
+    set(CLP_FFI_JS_VERSION
+        ${CMAKE_MATCH_1}
+        CACHE STRING
+        "The version of the project parsed from `package.json`."
+        FORCE
+    )
+else()
+    set(CLP_FFI_JS_VERSION "0.0.0" CACHE STRING "Use a placeholder version." FORCE)
+endif()
+
 project(
-    clp-ffi-js
+    ${CLP_FFI_JS_PROJECT_NAME}
     LANGUAGES
         C
         CXX
-    VERSION 0.3.1
+    VERSION "${CLP_FFI_JS_VERSION}"
 )
 
 # Enable exporting compile commands

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
 endif()
 
 project(
-    ${CLP_FFI_JS_PROJECT_NAME}
+    "${CLP_FFI_JS_PROJECT_NAME}"
     LANGUAGES
         C
         CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,24 +16,14 @@ else()
     message(FATAL_ERROR "`package.json` not found in ${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 if("${CLP_FFI_JS_PACKAGE_JSON_CONTENT}" MATCHES "\"name\":[ ]*\"([^\"]+)\"")
-    set(CLP_FFI_JS_PROJECT_NAME
-            "${CMAKE_MATCH_1}"
-            CACHE STRING
-            "The name of the project parsed from `package.json`."
-            FORCE
-    )
+    set(CLP_FFI_JS_PROJECT_NAME "${CMAKE_MATCH_1}")
 else()
-    set(CLP_FFI_JS_PROJECT_NAME "clp-ffi-js" CACHE STRING "Use a placeholder project name." FORCE)
+    set(CLP_FFI_JS_PROJECT_NAME "clp-ffi-js")
 endif()
 if("${CLP_FFI_JS_PACKAGE_JSON_CONTENT}" MATCHES "\"version\":[ ]*\"([^\"]+)\"")
-    set(CLP_FFI_JS_VERSION
-        "${CMAKE_MATCH_1}"
-        CACHE STRING
-        "The version of the project parsed from `package.json`."
-        FORCE
-    )
+    set(CLP_FFI_JS_VERSION "${CMAKE_MATCH_1}")
 else()
-    set(CLP_FFI_JS_VERSION "0.0.0" CACHE STRING "Use a placeholder version." FORCE)
+    set(CLP_FFI_JS_VERSION "0.0.0")
 endif()
 
 project(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/package.json")
 else()
     message(FATAL_ERROR "`package.json` not found in ${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
-if(${PACKAGE_JSON_CONTENT} MATCHES "\"name\":[ ]*\"([^\"]+)\"")
+if("${PACKAGE_JSON_CONTENT}" MATCHES "\"name\":[ ]*\"([^\"]+)\"")
     set(CLP_FFI_JS_PROJECT_NAME
-            ${CMAKE_MATCH_1}
+            "${CMAKE_MATCH_1}"
             CACHE STRING
             "The name of the project parsed from `package.json`."
             FORCE
@@ -25,9 +25,9 @@ if(${PACKAGE_JSON_CONTENT} MATCHES "\"name\":[ ]*\"([^\"]+)\"")
 else()
     set(CLP_FFI_JS_PROJECT_NAME "clp-ffi-js" CACHE STRING "Use a placeholder project name." FORCE)
 endif()
-if(${PACKAGE_JSON_CONTENT} MATCHES "\"version\":[ ]*\"([^\"]+)\"")
+if("${PACKAGE_JSON_CONTENT}" MATCHES "\"version\":[ ]*\"([^\"]+)\"")
     set(CLP_FFI_JS_VERSION
-        ${CMAKE_MATCH_1}
+        "${CMAKE_MATCH_1}"
         CACHE STRING
         "The version of the project parsed from `package.json`."
         FORCE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,11 @@ Emscripten.cmake"
 endif()
 
 # Extract the project name & version from package.json
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.json" PACKAGE_JSON_CONTENT)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/package.json")
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/package.json" PACKAGE_JSON_CONTENT)
+else()
+    message(FATAL_ERROR "`package.json` not found in ${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
 if(${PACKAGE_JSON_CONTENT} MATCHES "\"name\":[ ]*\"([^\"]+)\"")
     set(CLP_FFI_JS_PROJECT_NAME
             ${CMAKE_MATCH_1}


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Extract CMake project name and version from `package.json`.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
## Positive test
1. Ran `task` in the project root.
2. Under the project root, `cd build/clp-ffi-js`.
3. Ran `cmake -LAH | grep -B 1 CLP_FFI_JS` and saw below in the output:
    ```
    ...
    // The name of the project parsed from `package.json`.
    CLP_FFI_JS_PROJECT_NAME:STRING=clp-ffi-js
    --
    // The version of the project parsed from `package.json`.
    CLP_FFI_JS_VERSION:STRING=0.3.1
    ```
4. Compare that with the one in `package.json` and found no discrepancy.

## Negative test
1. Removed line `"version": "0.3.1",` from `package.json`.
2. Repeat above positive test steps 1-3 and saw
    ```
    ...
    // The name of the project parsed from `package.json`.
    CLP_FFI_JS_PROJECT_NAME:STRING=clp-ffi-js
    --
    // Use a placeholder version.
    CLP_FFI_JS_VERSION:STRING=0.0.0
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Project name and version are now dynamically extracted from `package.json`, enhancing configurability.
- **Bug Fixes**
	- Improved handling of project name and version defaults if not specified in `package.json`.
- **Chores**
	- Updated build configurations to ensure correct toolchain usage for Emscripten builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->