### PR TITLE
Rename LogLevel enum values to use PascalCase; prefix enum class specific values with the enum name (fixes #39).

### DIFF
--- a/src/clp_ffi_js/constants.hpp
+++ b/src/clp_ffi_js/constants.hpp
@@ -11,26 +11,26 @@ namespace clp_ffi_js {
  * Enum of known log levels.
  */
 enum class LogLevel : std::uint8_t {
-    NONE = 0,  // This isn't a valid log level.
-    TRACE,
-    DEBUG,
-    INFO,
-    WARN,
-    ERROR,
-    FATAL,
-    LENGTH,  // This isn't a valid log level.
+    LogLevelNone = 0,  // This isn't a valid log level.
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
+    LogLevelLength,
 };
-constexpr LogLevel cValidLogLevelsBeginIdx{LogLevel::TRACE};
+constexpr LogLevel cValidLogLevelsBeginIdx{LogLevel::Trace};
 
 /**
  * Strings corresponding to `LogLevel`.
  *
  * NOTE: These must be kept in sync manually.
  */
-constexpr std::array<std::string_view, clp::enum_to_underlying_type(LogLevel::LENGTH)>
+constexpr std::array<std::string_view, clp::enum_to_underlying_type(LogLevel::LogLevelLength)>
         cLogLevelNames{
                 "NONE",  // This isn't a valid log level.
-                "TRACE",
+                "Trace",
                 "DEBUG",
                 "INFO",
                 "WARN",

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -28,7 +28,7 @@ namespace {
  * Parses a string to determine the corresponding `LogLevel` enum value.
  * @param str
  * @return `LogLevel` enum corresponding to `str` if `str` matches a string in `cLogLevelNames`.
- * @return `LogLevel::NONE` otherwise.
+ * @return `LogLevel::LogLevelNone` otherwise.
  */
 auto parse_log_level(std::string_view str) -> LogLevel;
 
@@ -48,7 +48,7 @@ auto parse_log_level(std::string_view str) -> LogLevel {
             log_level_name_upper_case
     );
     if (it == cLogLevelNames.end()) {
-        return LogLevel::NONE;
+        return LogLevel::LogLevelNone;
     }
 
     return static_cast<LogLevel>(std::distance(cLogLevelNames.begin(), it));
@@ -96,7 +96,7 @@ auto StructuredIrUnitHandler::handle_end_of_stream() -> clp::ffi::ir_stream::IRE
 auto StructuredIrUnitHandler::get_log_level(
         StructuredLogEvent::NodeIdValuePairs const& id_value_pairs
 ) const -> LogLevel {
-    LogLevel log_level{LogLevel::NONE};
+    LogLevel log_level{LogLevel::LogLevelNone};
 
     if (false == m_log_level_node_id.has_value()) {
         return log_level;
@@ -113,7 +113,7 @@ auto StructuredIrUnitHandler::get_log_level(
     } else if (log_level_value.is<clp::ffi::value_int_t>()) {
         auto const& log_level_int = log_level_value.get_immutable_view<clp::ffi::value_int_t>();
         if (log_level_int >= clp::enum_to_underlying_type(cValidLogLevelsBeginIdx)
-            && log_level_int < clp::enum_to_underlying_type(LogLevel::LENGTH))
+            && log_level_int < clp::enum_to_underlying_type(LogLevel::LogLevelLength))
         {
             log_level = static_cast<LogLevel>(log_level_int);
         }

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.hpp
@@ -82,7 +82,7 @@ private:
     // Methods
     /**
      * @param id_value_pairs
-     * @return `LogLevel::NONE` if `m_log_level_node_id` is unset, the node has no value, or the
+     * @return `LogLevel::LogLevelNone` if `m_log_level_node_id` is unset, the node has no value, or the
      * node's value is not an integer or string.
      * @return `LogLevel` from node with id `m_log_level_node_id` otherwise.
      */

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
@@ -107,7 +107,7 @@ auto UnstructuredIrStreamReader::deserialize_stream() -> size_t {
 
         auto const& logtype = message.get_logtype();
         constexpr size_t cLogLevelPositionInMessages{1};
-        LogLevel log_level{LogLevel::NONE};
+        LogLevel log_level{LogLevel::LogLevelNone};
         if (logtype.length() > cLogLevelPositionInMessages) {
             // NOLINTNEXTLINE(readability-qualified-auto)
             auto const log_level_name_it{std::find_if(


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Rename LogLevel enum values to use PascalCase.
2. Prefix enum class specific values with the enum name 

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Ran `task` to build the project and ensured there was no compilation error or warnings.
