### PR TITLE
ci(publish-to-npm): Download and extract build as single artifact at the correct path (fixes #48).

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -23,6 +23,7 @@ jobs:
       - name: "Upload build artifacts"
         uses: "actions/upload-artifact@v4"
         with:
+          name: "dist"
           path: "dist/"
           if-no-files-found: "error"
           retention-days: 1
@@ -34,6 +35,7 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "actions/download-artifact@v4"
         with:
+          name: "dist"
           path: "dist/"
 
       - uses: "actions/setup-node@v4"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/download-artifact@v4"
+        with:
+          path: "dist/"
 
       - uses: "actions/setup-node@v4"
         with:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -5,6 +5,9 @@ on:
     types: ["created"]
   workflow_dispatch:
 
+env:
+  G_CLP_FFI_JS_DIST_ARTIFACT_NAME: "clp-ffi-js-dist-${{github.sha}}"
+
 permissions: {}
 
 jobs:
@@ -23,7 +26,7 @@ jobs:
       - name: "Upload build artifacts"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "dist"
+          name: "${{env.G_CLP_FFI_JS_DIST_ARTIFACT_NAME}}"
           path: "dist/"
           if-no-files-found: "error"
           retention-days: 1
@@ -35,7 +38,7 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "actions/download-artifact@v4"
         with:
-          name: "dist"
+          name: "${{env.G_CLP_FFI_JS_DIST_ARTIFACT_NAME}}"
           path: "dist/"
 
       - uses: "actions/setup-node@v4"


### PR DESCRIPTION
Related: #48 
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. ci(publish-to-npm): Fix incorrect artifact download path.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. With this debug workflow file: https://github.com/junhaoliao/clp-ffi-js/actions/runs/12554958088/workflow , `ls -l dist` in the debug job showed all the artifacts: https://github.com/junhaoliao/clp-ffi-js/actions/runs/12554958088/job/35004441486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for npm publishing.
	- Improved artifact management during build and publish processes.
	- Enhanced workflow reliability with explicit artifact handling and error conditions.
	- Introduced a new environment variable for unique artifact naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->