### PR TITLE
fix: Handle invalid UTF-8 sequences gracefully when converting structured log events to JSON.

### DIFF
--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.cpp
@@ -30,14 +30,14 @@ constexpr std::string_view cReaderOptionsTimestampKey{"timestampKey"};
 
 /**
  * @see nlohmann::basic_json::dump
- * Dumps a JSON value with error handling set to replace invalid UTF-8 characters rather than
+ * Serializes a JSON value into a string with invalid UTF-8 sequences replaced rather than
  * throwing an exception.
  * @param json
  * @return Serialized JSON.
  */
-auto json_dump_with_replace(nlohmann::json const& json) -> std::string;
+auto dump_json_with_replace(nlohmann::json const& json) -> std::string;
 
-auto json_dump_with_replace(nlohmann::json const& json) -> std::string {
+auto dump_json_with_replace(nlohmann::json const& json) -> std::string {
     return json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
 }
 
@@ -147,7 +147,7 @@ auto StructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bo
             );
             json_str = std::string(cEmptyJsonStr);
         } else {
-            json_str = json_dump_with_replace(json_result.value());
+            json_str = dump_json_with_replace(json_result.value());
         }
         return json_str;
     };


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->
# Description
Fixes issue where some files with invalid UTF-8 could not be opened. Now chars are just replaced.


# Validation performed
Tested file could now be opened. Tested older IRV2 test file still worked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved JSON serialization error handling by replacing invalid UTF-8 characters.
	- Enhanced output formatting for JSON string conversion.

These changes provide a more flexible approach to converting structured data to JSON, ensuring better compatibility and error management during serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->