### PR TITLE
feat!: Remove timestamp formatting from unstructured log messages.

### DIFF
--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
@@ -160,9 +160,10 @@ auto UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, 
 UnstructuredIrStreamReader::UnstructuredIrStreamReader(
         StreamReaderDataContext<UnstructuredIrDeserializer>&& stream_reader_data_context
 )
-        : m_stream_reader_data_context{std::make_unique<
-                  StreamReaderDataContext<UnstructuredIrDeserializer>>(
-                  std::move(stream_reader_data_context)
-          )} {}
+        : m_stream_reader_data_context{
+                  std::make_unique<StreamReaderDataContext<UnstructuredIrDeserializer>>(
+                          std::move(stream_reader_data_context)
+                  )
+          } {}
 
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
@@ -133,7 +133,6 @@ auto UnstructuredIrStreamReader::deserialize_stream() -> size_t {
 auto UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filter)
         const -> DecodedResultsTsType {
     auto log_event_to_string = [this](UnstructuredLogEvent const& log_event) -> std::string {
-        std::string message;
         auto const parsed{log_event.get_message().decode_and_unparse()};
         if (false == parsed.has_value()) {
             throw ClpFfiJsException{
@@ -143,8 +142,7 @@ auto UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, 
                     "Failed to decode message"
             };
         }
-        message = parsed.value();
-        return message;
+        return parsed.value();
     };
 
     return generic_decode_range(

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
@@ -144,7 +144,6 @@ auto UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, 
             };
         }
         message = parsed.value();
-        m_ts_pattern.insert_formatted_timestamp(log_event.get_timestamp(), message);
         return message;
     };
 
@@ -164,7 +163,6 @@ UnstructuredIrStreamReader::UnstructuredIrStreamReader(
         : m_stream_reader_data_context{std::make_unique<
                   StreamReaderDataContext<UnstructuredIrDeserializer>>(
                   std::move(stream_reader_data_context)
-          )},
-          m_ts_pattern{m_stream_reader_data_context->get_deserializer().get_timestamp_pattern()} {}
+          )} {}
 
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -7,7 +7,6 @@
 
 #include <clp/ir/LogEventDeserializer.hpp>
 #include <clp/ir/types.hpp>
-#include <clp/TimestampPattern.hpp>
 #include <emscripten/val.h>
 
 #include <clp_ffi_js/ir/LogEventWithFilterData.hpp>

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -82,7 +82,6 @@ private:
     std::unique_ptr<StreamReaderDataContext<UnstructuredIrDeserializer>>
             m_stream_reader_data_context;
     FilteredLogEventsMap m_filtered_log_event_map;
-    clp::TimestampPattern m_ts_pattern;
 };
 }  // namespace clp_ffi_js::ir
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Remove all references to m_ts_pattern from the UnstructuredIRStreamReader. We will no longer be formatting these timestamps here and will be allowing the log-viewer to handle formatting it using a custom DayJS format string from the user.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Made sure the timestamp was not inserted into the message and that the updated files ran successfully with the log-viewer.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified log event processing by removing the inclusion of a formatted timestamp in log messages.
  - Streamlined component initialization by eliminating dependencies related to timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->