### PR TITLE
chore: Update linting requirements and tasks for improved code formatting.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,7 @@ version: "3"
 
 includes:
   lint: "lint-tasks.yml"
-  utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
+  utils: "tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 
 vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
@@ -45,10 +45,10 @@ tasks:
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
       - "emsdk"
-      - task: "utils:validate-checksum"
+      - task: "utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - task: "config-cmake-project"
       - >-
@@ -57,10 +57,10 @@ tasks:
         --parallel
         --target {{range .G_CLP_FFI_JS_ENV_NAMES}}"{{$.G_CLP_FFI_JS_TARGET_PREFIX}}{{.}}" {{end}}
       # This command must be last
-      - task: "utils:compute-checksum"
+      - task: "utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   emsdk:
     vars:
@@ -73,11 +73,10 @@ tasks:
     run: "once"
     deps:
       - "init"
-      - task: "utils:validate-checksum"
+      - task: "utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          EXCLUDE_PATHS: &emsdk_checksum_exclude_paths
+          EXCLUDE_PATTERNS: &emsdk_checksum_exclude_paths
             - "upstream/emscripten/__pycache__"
             - "upstream/emscripten/cache/sanity.txt"
             - "upstream/emscripten/cache/symbol_lists"
@@ -87,6 +86,7 @@ tasks:
             - "upstream/emscripten/tools/__pycache__"
             - "upstream/emscripten/tools/ports/__pycache__"
             - "upstream/emscripten/tools/ports/contrib/__pycache__"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - task: "clean-emsdk"
       - "git clone https://github.com/emscripten-core/emsdk.git '{{.G_EMSDK_DIR}}'"
@@ -98,11 +98,11 @@ tasks:
         cd "{{.G_EMSDK_DIR}}/upstream/emscripten"
         PATH=$(echo {{.G_EMSDK_DIR}}/node/*/bin):$PATH npm install
       # This command must be last
-      - task: "utils:compute-checksum"
+      - task: "utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           EXCLUDE_PATHS: *emsdk_checksum_exclude_paths
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   package:
     vars:
@@ -114,10 +114,10 @@ tasks:
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
       - "clp-ffi-js"
-      - task: "utils:validate-checksum"
+      - task: "utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - "rm -rf {{.OUTPUT_DIR}}"
       - for:
@@ -128,10 +128,10 @@ tasks:
           "{{.OUTPUT_DIR}}/"
       - "npm pack"
       # This command must be last
-      - task: "utils:compute-checksum"
+      - task: "utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
 
   config-cmake-project:
     internal: true

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,3 @@
-# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
-clang-format~=18.1
-clang-tidy>=19.1.0
+clang-format>=20.1
+clang-tidy>=20.1
 yamllint>=1.35.1

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -1,127 +1,154 @@
 version: "3"
 
 vars:
+  G_LINT_CLANG_TIDY_DIR: "{{.G_BUILD_DIR}}/lint-clang-tidy"
+  G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
   G_SRC_DIR: "{{.ROOT_DIR}}/src"
   G_SRC_CLP_FFI_JS_DIR: "{{.G_SRC_DIR}}/clp_ffi_js"
-  G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
 
 tasks:
   check:
     cmds:
-      - task: "cpp-check"
-      - task: "yml-check"
+      - task: "check-cpp-full"
+      - task: "check-yaml"
+
+  check-cpp-diff:
+    cmds:
+      - task: "check-cpp-format"
+      - task: "check-cpp-static-diff"
+
+  check-cpp-full:
+    cmds:
+      - task: "check-cpp-format"
+      - task: "check-cpp-static-full"
+
+  check-no-cpp:
+    cmds:
+      - task: "check-yaml"
 
   fix:
     cmds:
-      - task: "cpp-fix"
-      - task: "yml-fix"
+      - task: "fix-cpp-full"
+      - task: "fix-yaml"
 
-  cpp-configs:
-    cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
-
-  cpp-check:
+  fix-cpp-diff:
     cmds:
-      - task: "cpp-format-check"
-      - task: "cpp-static-check"
+      - task: "fix-cpp-format"
+      - task: "fix-cpp-static-diff"
 
-  cpp-fix:
+  fix-cpp-full:
     cmds:
-      - task: "cpp-format-fix"
-      - task: "cpp-static-fix"
+      - task: "fix-cpp-format"
+      - task: "fix-cpp-static-full"
 
-  cpp-format-check:
+  fix-no-cpp:
+    cmds:
+      - task: "fix-yaml"
+
+  check-cpp-format:
     sources: &cpp_format_source_files
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/.clang-format"
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
-      - "{{.TASKFILE}}"
-      - "tools/yscope-dev-utils/lint-configs/.clang-format"
-    deps: ["cpp-configs", "venv"]
+        - "{{.G_SRC_CLP_FFI_JS_DIR}}/.clang-format"
+        - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*"
+        - "{{.TASKFILE}}"
+        - "tools/yscope-dev-utils/exports/lint-configs/.clang-format"
+    deps: ["cpp-lint-configs", "venv"]
     cmds:
-      - task: "clang-format"
+      - task: ":utils:cpp-lint:clang-format"
         vars:
-          FLAGS: "--dry-run"
+          FLAGS: ["--dry-run"]
+          INCLUDE_FILENAME_PATTERNS: ["*.cpp", "*.h", "*.hpp", "*.inc"]
+          ROOT_PATHS: *cpp_format_source_files
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
-  cpp-format-fix:
+  fix-cpp-format:
     sources: *cpp_format_source_files
-    deps: ["cpp-configs", "venv"]
+    deps: ["cpp-lint-configs", "venv"]
     cmds:
-      - task: "clang-format"
+      - task: ":utils:cpp-lint:clang-format"
         vars:
-          FLAGS: "-i"
+          FLAGS: ["-i"]
+          INCLUDE_FILENAME_PATTERNS: ["*.cpp", "*.h", "*.hpp", "*.inc"]
+          ROOT_PATHS: *cpp_format_source_files
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
-  cpp-static-check:
-    # Alias task to `cpp-static-fix` since we don't currently support automatic fixes.
-    # NOTE: clang-tidy does have the ability to fix some errors, but the fixes can be inaccurate.
-    # When we eventually determine which errors can be safely fixed, we'll allow clang-tidy to
-    # fix them.
-    aliases: ["cpp-static-fix"]
-    sources:
-      # Dependency sources
-      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/_deps/*-src/**/*"
-      - "{{.G_SRC_DIR}}/submodules/**/*"
+  check-cpp-static-diff:
+    # NOTE: We alias the fix task until we determine which clang-tidy fixes can be applied safely.
+    aliases: [ "fix-cpp-static-diff" ]
+    sources: &cpp_static_source_files
+        # Dependency sources
+        - "{{.G_CLP_FFI_JS_BUILD_DIR}}/_deps/*-src/**/*"
+        - "{{.G_SRC_DIR}}/submodules/**/*"
 
-      # clp-ffi-js sources
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.cpp"
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.h"
-      - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*.hpp"
+        # Source files
+        - "{{.G_SRC_CLP_FFI_JS_DIR}}/**/*"
 
-      # Other sources
-      - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
-      - "{{.ROOT_DIR}}/Taskfile.yml"
-      - "{{.TASKFILE}}"
-      - "tools/yscope-dev-utils/lint-configs/.clang-tidy"
-    deps: [":config-cmake-project", "cpp-configs", "venv"]
+        # Other sources
+        - "{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json"
+        - "{{.ROOT_DIR}}/Taskfile.yml"
+        - "{{.TASKFILE}}"
+        - "tools/yscope-dev-utils/exports/lint-configs/.clang-tidy"
+    deps:
+      - ":config-cmake-project"
+      - "cpp-lint-configs"
+      - "venv"
     cmds:
-      - task: "clang-tidy"
+      - task: ":utils:cpp-lint:clang-tidy-diff"
+        vars:
+          FLAGS:
+            - "--config-file '{{.ROOT_DIR}}/.clang-tidy'"
+            - "-p '{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json'"
+            - >-
+              $("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
+                | tr ' ' '\n' \
+                | sed 's/^/--extra-arg /' \
+                | tr '\n' ' ')
+          OUTPUT_DIR: "{{.G_LINT_CLANG_TIDY_DIR}}"
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
-  yml:
+  check-cpp-static-full:
+    # NOTE: We alias the fix task until we determine which clang-tidy fixes can be applied safely.
+    aliases: ["fix-cpp-static-full"]
+    sources: *cpp_static_source_files
+    deps:
+      - ":config-cmake-project"
+      - "cpp-lint-configs"
+      - "venv"
+    cmds:
+      - task: ":utils:cpp-lint:clang-tidy-find"
+        vars:
+          FLAGS:
+            - "--config-file '{{.ROOT_DIR}}/.clang-tidy'"
+            - "-p '{{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json'"
+            - >-
+              $("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
+                | tr ' ' '\n' \
+                | sed 's/^/--extra-arg /' \
+                | tr '\n' ' ')
+          INCLUDE_PATTERNS:
+            - "{{.G_SRC_CLP_FFI_JS_DIR}}/*"
+          OUTPUT_DIR: "{{.G_LINT_CLANG_TIDY_DIR}}"
+          ROOT_PATHS: *cpp_static_source_files
+          VENV_DIR: "{{.G_LINT_VENV_DIR}}"
+
+  yaml:
     aliases:
-      - "yml-check"
-      - "yml-fix"
+      - "check-yaml"
+      - "fix-yaml"
     deps: ["venv"]
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
         yamllint \
-          --config-file "{{.ROOT_DIR}}/tools/yscope-dev-utils/lint-configs/.yamllint.yml" \
+          --config-file "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
           --strict \
           .github \
           lint-tasks.yml \
           Taskfile.yml
 
-  clang-format:
+  cpp-lint-configs:
     internal: true
-    requires:
-      vars: ["FLAGS"]
-    cmd: |-
-      . "{{.G_LINT_VENV_DIR}}/bin/activate"
-      find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
-        -type f \
-        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
-        -print0 | \
-          xargs -0 clang-format {{.FLAGS}} -Werror
-
-  clang-tidy:
-    internal: true
-    vars:
-      FLAGS: >-
-        -p {{.G_CLP_FFI_JS_BUILD_DIR}}/compile_commands.json
-        --config-file=.clang-tidy
-    cmd: |-
-      . "{{.G_LINT_VENV_DIR}}/bin/activate"
-
-      # Pass emscripten's cflags to clang-tidy by prefixing each one with `--extra-arg`
-      EXTRA_ARGS=$("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
-        | tr ' ' '\n' \
-        | sed 's/^/--extra-arg /' \
-        | tr '\n' ' ')
-      find "{{.G_SRC_CLP_FFI_JS_DIR}}" \
-        -type f \
-        \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
-        -print0 | \
-          xargs -0 clang-tidy {{.FLAGS}} $EXTRA_ARGS
+    run: "once"
+    cmd: "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/symlink-cpp-lint-configs.sh"
 
   venv:
     internal: true
@@ -133,20 +160,21 @@ tasks:
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]
+    run: "once"
     deps:
       - ":init"
-      - task: ":utils:validate-checksum"
+      - task: ":utils:checksum:validate"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
-      - task: ":utils:create-venv"
+      - task: ":utils:misc:create-venv"
         vars:
           LABEL: "lint"
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
           REQUIREMENTS_FILE: "lint-requirements.txt"
       # This command must be last
-      - task: ":utils:compute-checksum"
+      - task: ":utils:checksum:compute"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]

--- a/src/clp_ffi_js/ir/StreamReader.cpp
+++ b/src/clp_ffi_js/ir/StreamReader.cpp
@@ -77,7 +77,8 @@ auto get_version(clp::ReaderInterface& reader) -> std::string {
     // Deserialize metadata bytes from preamble.
     clp::ffi::ir_stream::encoded_tag_t metadata_type{};
     std::vector<int8_t> metadata_bytes;
-    auto const err{clp::ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata_bytes)
+    auto const err{
+            clp::ffi::ir_stream::deserialize_preamble(reader, metadata_type, metadata_bytes)
     };
     if (IRErrorCode::IRErrorCode_Success != err) {
         throw ClpFfiJsException{
@@ -177,7 +178,8 @@ auto StreamReader::create(DataArrayTsType const& data_array, ReaderOptions const
     auto pos = zstd_decompressor->get_pos();
     auto const version{get_version(*zstd_decompressor)};
     try {
-        auto const version_validation_result{clp::ffi::ir_stream::validate_protocol_version(version)
+        auto const version_validation_result{
+                clp::ffi::ir_stream::validate_protocol_version(version)
         };
         if (clp::ffi::ir_stream::IRProtocolErrorCode::Supported == version_validation_result) {
             zstd_decompressor->seek_from_begin(0);

--- a/src/clp_ffi_js/ir/StreamReader.hpp
+++ b/src/clp_ffi_js/ir/StreamReader.hpp
@@ -62,10 +62,9 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(
-            DataArrayTsType const& data_array,
-            ReaderOptions const& reader_options
-    ) -> std::unique_ptr<StreamReader>;
+    [[nodiscard]] static auto
+    create(DataArrayTsType const& data_array, ReaderOptions const& reader_options)
+            -> std::unique_ptr<StreamReader>;
 
     // Destructor
     virtual ~StreamReader() = default;
@@ -124,7 +123,8 @@ public:
      * @throw ClpFfiJsException if a message cannot be decoded.
      */
     [[nodiscard]] virtual auto decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
-            -> DecodedResultsTsType = 0;
+            -> DecodedResultsTsType
+            = 0;
 
     /**
      * Finds the log event, L, where if we assume:
@@ -143,9 +143,9 @@ public:
      * @param target_ts
      * @return The index of the log event L.
      */
-    [[nodiscard]] virtual auto find_nearest_log_event_by_timestamp(
-            clp::ir::epoch_time_ms_t target_ts
-    ) -> NullableLogEventIdx = 0;
+    [[nodiscard]] virtual auto
+    find_nearest_log_event_by_timestamp(clp::ir::epoch_time_ms_t target_ts) -> NullableLogEventIdx
+            = 0;
 
 protected:
     explicit StreamReader() = default;

--- a/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrStreamReader.hpp
@@ -75,8 +75,8 @@ public:
     [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
             -> DecodedResultsTsType override;
 
-    [[nodiscard]] auto find_nearest_log_event_by_timestamp(clp::ir::epoch_time_ms_t target_ts
-    ) -> NullableLogEventIdx override;
+    [[nodiscard]] auto find_nearest_log_event_by_timestamp(clp::ir::epoch_time_ms_t target_ts)
+            -> NullableLogEventIdx override;
 
 private:
     // Constructor

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -42,8 +42,8 @@ namespace {
  * - Forwards `clp::ir::EncodedTextAst::decode_and_unparse`'s return values.
  * - Forwards `parse_log_level`'s return values.
  */
-[[nodiscard]] auto parse_log_level_from_value(clp::ffi::Value const& value
-) -> std::optional<LogLevel>;
+[[nodiscard]] auto parse_log_level_from_value(clp::ffi::Value const& value)
+        -> std::optional<LogLevel>;
 
 auto parse_log_level(std::string_view str) -> std::optional<LogLevel> {
     // Convert the string to uppercase.
@@ -129,8 +129,8 @@ auto StructuredIrUnitHandler::SchemaTreeFullBranch::match(
     return true;
 }
 
-auto StructuredIrUnitHandler::handle_log_event(StructuredLogEvent&& log_event
-) -> clp::ffi::ir_stream::IRErrorCode {
+auto StructuredIrUnitHandler::handle_log_event(StructuredLogEvent&& log_event)
+        -> clp::ffi::ir_stream::IRErrorCode {
     auto const timestamp = get_timestamp(log_event);
     auto const log_level = get_log_level(log_event);
 
@@ -233,8 +233,8 @@ auto StructuredIrUnitHandler::get_log_level(StructuredLogEvent const& log_event)
     return optional_log_level.value();
 }
 
-auto StructuredIrUnitHandler::get_timestamp(StructuredLogEvent const& log_event
-) const -> clp::ir::epoch_time_ms_t {
+auto StructuredIrUnitHandler::get_timestamp(StructuredLogEvent const& log_event) const
+        -> clp::ir::epoch_time_ms_t {
     constexpr clp::ir::epoch_time_ms_t cDefaultTimestamp{0};
 
     if (false == m_optional_timestamp_full_branch.has_value()) {

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.hpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.hpp
@@ -104,8 +104,8 @@ public:
      * @param log_event
      * @return IRErrorCode::IRErrorCode_Success
      */
-    [[nodiscard]] auto handle_log_event(StructuredLogEvent&& log_event
-    ) -> clp::ffi::ir_stream::IRErrorCode;
+    [[nodiscard]] auto handle_log_event(StructuredLogEvent&& log_event)
+            -> clp::ffi::ir_stream::IRErrorCode;
 
     /**
      * Dummy implementation that does nothing but conforms to the interface.
@@ -158,8 +158,8 @@ private:
      * - `m_optional_timestamp_id` is set but not appearing in the given node-id-value pairs.
      * - The value is not a valid integer.
      */
-    [[nodiscard]] auto get_timestamp(StructuredLogEvent const& log_event
-    ) const -> clp::ir::epoch_time_ms_t;
+    [[nodiscard]] auto get_timestamp(StructuredLogEvent const& log_event) const
+            -> clp::ir::epoch_time_ms_t;
 
     // Variables
     std::optional<SchemaTreeFullBranch> m_optional_log_level_full_branch;

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.cpp
@@ -26,7 +26,6 @@
 #include <clp_ffi_js/ir/StreamReaderDataContext.hpp>
 
 namespace clp_ffi_js::ir {
-
 using namespace std::literals::string_literals;
 using clp::ir::four_byte_encoded_variable_t;
 
@@ -130,8 +129,9 @@ auto UnstructuredIrStreamReader::deserialize_stream() -> size_t {
     return m_encoded_log_events.size();
 }
 
-auto UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filter)
-        const -> DecodedResultsTsType {
+auto
+UnstructuredIrStreamReader::decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
+        -> DecodedResultsTsType {
     auto log_event_to_string = [this](UnstructuredLogEvent const& log_event) -> std::string {
         auto const parsed{log_event.get_message().decode_and_unparse()};
         if (false == parsed.has_value()) {
@@ -169,5 +169,4 @@ UnstructuredIrStreamReader::UnstructuredIrStreamReader(
                           std::move(stream_reader_data_context)
                   )
           } {}
-
 }  // namespace clp_ffi_js::ir

--- a/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
+++ b/src/clp_ffi_js/ir/UnstructuredIrStreamReader.hpp
@@ -43,10 +43,9 @@ public:
      * @return The created instance.
      * @throw ClpFfiJsException if any error occurs.
      */
-    [[nodiscard]] static auto create(
-            std::unique_ptr<ZstdDecompressor>&& zstd_decompressor,
-            clp::Array<char> data_array
-    ) -> UnstructuredIrStreamReader;
+    [[nodiscard]] static auto
+    create(std::unique_ptr<ZstdDecompressor>&& zstd_decompressor, clp::Array<char> data_array)
+            -> UnstructuredIrStreamReader;
 
     [[nodiscard]] auto get_ir_stream_type() const -> StreamType override {
         return StreamType::Unstructured;
@@ -70,8 +69,8 @@ public:
     [[nodiscard]] auto decode_range(size_t begin_idx, size_t end_idx, bool use_filter) const
             -> DecodedResultsTsType override;
 
-    [[nodiscard]] auto find_nearest_log_event_by_timestamp(clp::ir::epoch_time_ms_t target_ts
-    ) -> NullableLogEventIdx override;
+    [[nodiscard]] auto find_nearest_log_event_by_timestamp(clp::ir::epoch_time_ms_t target_ts)
+            -> NullableLogEventIdx override;
 
 private:
     // Constructor


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

1. Update submodule `yscope-dev-utils` version to y-scope/yscope-dev-utils@76aecbd6d0db6e2078005431946b5c2e716c4291
2. Update references to `yscope-dev-utils` utilities in both `Taskfile.yml` and `lint-tasks.yml`.
3. Update versions in `linting-requirements.txt` using https://github.com/y-scope/clp/blob/8d008abe40ca1ae4531d05b4dbd9085ff0ce53ed/lint-requirements.txt as a reference.
4. Apply latest formatting and linting configurations by running the updated task.

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

TBA

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
