### PR TITLE
build: Reuse CMake ClpFfiJs compile options for C++ code linting (fixes #82).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
         --closure=1
     )
 endif()
+set(CLP_FFI_JS_COMMON_COMPILE_OPTIONS
+    ${CLP_FFI_JS_COMMON_COMPILE_OPTIONS}
+    CACHE STRING
+    "Common compile options for ClpFfiJs. Exporting to cache so that it can be used in linting."
+    FORCE
+)
 
 set(CLP_FFI_JS_SRC_MAIN
     src/clp_ffi_js/ir/StreamReader.cpp

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -113,7 +113,15 @@ tasks:
       . "{{.G_LINT_VENV_DIR}}/bin/activate"
 
       # Pass emscripten's cflags to clang-tidy by prefixing each one with `--extra-arg`
-      EXTRA_ARGS=$("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" --cflags \
+      EXTRA_ARGS=$("{{.G_EMSDK_DIR}}/upstream/emscripten/em++" \
+        $(
+          cmake -L -N -S '{{.ROOT_DIR}}' \
+            -B '{{.G_CLP_FFI_JS_BUILD_DIR}}' \
+            | grep '^CLP_FFI_JS_COMMON_COMPILE_OPTIONS' \
+            | sed -n 's/^[^=]*=//p' \
+            | tr ';' ' ' \
+        ) \
+        --cflags \
         | tr ' ' '\n' \
         | sed 's/^/--extra-arg /' \
         | tr '\n' ' ')


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
1. Add `CLP_FFI_JS_COMMON_COMPILE_OPTIONS` as a cache variable in CMakeList.txt .
2. Read the options in `lint-tasks.yml` and pass those to `em++` before getting `--cflags`.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Ran `task lint:fix` and observed no error.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to make common compile options accessible for external tools.
  - Improved linting task to include additional project-specific compile options during code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->