### PR TITLE
fix: Upgrade CLP to correctly decode small Zstandard IR files (fixes #88).

### DIFF
--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -52,9 +52,9 @@ tasks:
     cmds:
       - task: ":utils:remote:download-and-extract-tar"
         vars:
-          FILE_SHA256: "9db9528c8fd2c97e6d88fb40892f93f33a6e3a64e47c643add2855dee397d571"
+          FILE_SHA256: "9315fbd3cbb46487e36a0156fae95f6edfc2de483bbde82df541d478e044c98b"
           OUTPUT_DIR: "{{.CLP_OUTPUT_DIR}}"
-          URL: "https://github.com/y-scope/clp/archive/412f6dc.tar.gz"
+          URL: "https://github.com/y-scope/clp/archive/88b8b46.tar.gz"
       - >-
         echo "set(
         CLP_FFI_JS_CLP_SOURCE_DIRECTORY \"{{.CLP_OUTPUT_DIR}}\"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

as the title says

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Repeated the reproduction steps in #88 .
2. Now observed one log event was decoded from that small file instead of deserialization failure.
    ```
    /home/junhao/.nvm/versions/node/v22.14.0/bin/node /home/junhao/workspace/clp-ffi-js/test.mjs
    auto-generated
    user-generated
    [2025-06-15 22:31:01.596] [info] [StreamReader.cpp:107] StreamReader::create: got buffer of length=238
    [2025-06-15 22:31:01.604] [info] [StreamReader.cpp:55] IR version is 0.1.0
    {
      VARIABLES_SCHEMA_ID: 'com.yscope.clp.VariablesSchemaV2',
      VARIABLE_ENCODING_METHODS_ID: 'com.yscope.clp.VariableEncodingMethodsV1',
      VERSION: '0.1.0'
    }
    type: true false
    [2025-06-15 22:31:01.620] [error] [StructuredIrStreamReader.cpp:162] File contains an incomplete IR stream
    1
    [
      [
        '{"auto-generated":{"timestamp":1749102847291},"user-generated":{"file_path":"/tmp/test-0.log","message":"{\\"message\\": \\"a log message\\"}"}}',
        0n,
        0,
        1
      ]
    ]
    perf: 66.802ms
    ```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the download URL and checksum for the "clp" dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210490535682646