### PR TITLE
fix(publish-to-npm): Pin go-task CLI to v3.44.0 to resolve path globbing issues.

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        run: "npm install --global @go-task/cli"
+        run: "npm install --global @go-task/cli@3.44.0"
 
       - run: "task package"
 


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the CI task runner to a specific version in the publish pipeline to ensure consistent installs and predictable release behaviour.
  * Improves reliability of the publish process without altering application functionality.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->