### PR TITLE
build(deps): Upgrade CLP to y-scope/clp@de9fc08 (resolves #112):

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ endif()
 # Disable response files since `clang-tidy` doesn't seem to be able to use them
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 
+# Allow `find_package(Boost)` to locate the Boost installation when cross-compiling with Emscripten,
+# whose toolchain file restricts package searches to `CMAKE_FIND_ROOT_PATH`.
+list(PREPEND CMAKE_FIND_ROOT_PATH "${Boost_ROOT}")
+
 # Set the default build type to Release if not specified
 if(NOT CMAKE_BUILD_TYPE)
     set(CLP_FFI_JS_DEFAULT_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ foreach(env ${CLP_FFI_JS_SUPPORTED_ENVIRONMENTS})
         embind
         fmt::fmt
         spdlog::spdlog
+        ystdlib::error_handling
     )
     set(CLP_FFI_JS_LINK_OPTIONS
         ${CLP_FFI_JS_COMMON_LINK_OPTIONS}
@@ -232,7 +233,6 @@ Link options: ${CLP_FFI_JS_LINK_OPTIONS}."
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp
         ${CLP_FFI_JS_NLOHMANN_JSON_SOURCE_DIRECTORY}/include
-        ${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY}/src
         ${CLP_FFI_JS_ZSTD_SOURCE_DIRECTORY}/lib
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-include(FetchContent)
-set(FETCHCONTENT_QUIET OFF)
-
 if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE
         "${CMAKE_CURRENT_SOURCE_DIR}/build/emsdk/upstream/emscripten/cmake/Modules/Platform/\
@@ -238,7 +235,6 @@ Link options: ${CLP_FFI_JS_LINK_OPTIONS}."
         ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY}
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp
-        ${CLP_FFI_JS_FMT_SOURCE_DIRECTORY}/include
         ${CLP_FFI_JS_NLOHMANN_JSON_SOURCE_DIRECTORY}/include
         ${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY}/src
         ${CLP_FFI_JS_ZSTD_SOURCE_DIRECTORY}/lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(CLP_FFI_JS_SRC_MAIN
 )
 
 set(CLP_FFI_JS_SRC_CLP_CORE
+    ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/ffi/EncodedTextAstError.cpp
     ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/ffi/ir_stream/decoding_methods.cpp
     ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/ffi/ir_stream/ir_unit_deserialization_methods.cpp
     ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/ffi/ir_stream/search/ErrorCode.cpp
@@ -125,8 +126,6 @@ set(CLP_FFI_JS_SRC_CLP_CORE
     ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/ReaderInterface.cpp
     ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/streaming_compression/zstd/Decompressor.cpp
 )
-
-set(CLP_FFI_JS_SRC_FMT ${CLP_FFI_JS_FMT_SOURCE_DIRECTORY}/src/format.cc)
 
 set(CLP_FFI_JS_SRC_ZSTD
     ${CLP_FFI_JS_ZSTD_SOURCE_DIRECTORY}/lib/common/entropy_common.c
@@ -150,6 +149,30 @@ set(CLP_FFI_JS_SUPPORTED_ENVIRONMENTS
 set(CLP_BUILD_CLP_STRING_UTILS ON)
 add_subdirectory(${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/string_utils)
 
+# Set up `Boost::headers` as a header-only interface target so that downstream dependencies
+# (e.g., ystdlib) can link against it without requiring a full Boost installation.
+if(NOT TARGET Boost::headers)
+    add_library(Boost_headers INTERFACE)
+    target_include_directories(Boost_headers INTERFACE ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY})
+    add_library(Boost::headers ALIAS Boost_headers)
+endif()
+
+# Set up ystdlib as a subproject to provide the `ystdlib::error_handling` target required by the CLP
+# core's `EncodedTextAstError` and `clp_s`'s `timestamp_parser`.
+set(Boost_INCLUDE_DIR "${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY}")
+set(YSTDLIB_CPP_BUILD_TESTING OFF)
+add_subdirectory(${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY} ystdlib)
+
+set(ANTLR_BUILD_SHARED OFF)
+set(ANTLR_BUILD_STATIC ON)
+add_subdirectory(${CLP_FFI_JS_ANTLR_RUNTIME_SOURCE_DIRECTORY})
+
+add_subdirectory(${CLP_FFI_JS_DATE_SOURCE_DIRECTORY})
+set(FMT_INSTALL OFF)
+add_subdirectory(${CLP_FFI_JS_FMT_SOURCE_DIRECTORY} fmt)
+add_subdirectory(${CLP_FFI_JS_SIMDJSON_SOURCE_DIRECTORY})
+add_subdirectory(${CLP_FFI_JS_SPDLOG_SOURCE_DIRECTORY})
+
 # The `clp_s` component is linked because the IR search feature uses the same KQL syntax as `clp_s`,
 # by reusing `clp_s`'s AST and KQL libraries.
 #
@@ -166,16 +189,9 @@ set(CLP_BUILD_CLP_S_REDUCER_DEPENDENCIES OFF)
 set(CLP_BUILD_CLP_S_SEARCH OFF)
 set(CLP_BUILD_CLP_S_SEARCH_AST ON)
 set(CLP_BUILD_CLP_S_SEARCH_KQL ON)
+set(CLP_BUILD_CLP_S_TIMESTAMP_PARSER ON)
 set(CLP_BUILD_CLP_S_TIMESTAMPPATTERN ON)
 add_subdirectory(${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp_s)
-
-set(ANTLR_BUILD_SHARED OFF)
-set(ANTLR_BUILD_STATIC ON)
-add_subdirectory(${CLP_FFI_JS_ANTLR_RUNTIME_SOURCE_DIRECTORY})
-
-add_subdirectory(${CLP_FFI_JS_DATE_SOURCE_DIRECTORY})
-add_subdirectory(${CLP_FFI_JS_SIMDJSON_SOURCE_DIRECTORY})
-add_subdirectory(${CLP_FFI_JS_SPDLOG_SOURCE_DIRECTORY})
 
 foreach(env ${CLP_FFI_JS_SUPPORTED_ENVIRONMENTS})
     set(CLP_FFI_JS_BIN_NAME "ClpFfiJs-${env}")
@@ -192,6 +208,7 @@ foreach(env ${CLP_FFI_JS_SUPPORTED_ENVIRONMENTS})
         clp_s::search::ast
         clp_s::search::kql
         embind
+        fmt::fmt
         spdlog::spdlog
     )
     set(CLP_FFI_JS_LINK_OPTIONS
@@ -234,7 +251,6 @@ Link options: ${CLP_FFI_JS_LINK_OPTIONS}."
         PRIVATE
         ${CLP_FFI_JS_SRC_MAIN}
         ${CLP_FFI_JS_SRC_CLP_CORE}
-        ${CLP_FFI_JS_SRC_FMT}
         ${CLP_FFI_JS_SRC_ZSTD}
     )
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ if(${CLP_FFI_JS_PROJECT_NAME}_IS_TOP_LEVEL)
     include("build/deps/cmake-settings/settings.cmake" OPTIONAL)
 endif()
 
+# Allow `find_package(Boost)` to locate the Boost installation when cross-compiling with Emscripten,
+# whose toolchain file restricts package searches to `CMAKE_FIND_ROOT_PATH`.
+if(Boost_ROOT)
+    list(APPEND CMAKE_FIND_ROOT_PATH "${Boost_ROOT}")
+endif()
+
 # Disable response files since `clang-tidy` doesn't seem to be able to use them
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 
@@ -166,10 +172,7 @@ set(CLP_BUILD_CLP_S_TIMESTAMP_PARSER ON)
 set(CLP_BUILD_CLP_S_TIMESTAMPPATTERN ON)
 add_subdirectory(${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp_s)
 
-# Set up `Boost::headers` as a header-only interface target so that `ystdlib` can link against it
-# without requiring a full Boost installation.
-add_library(Boost::headers IMPORTED INTERFACE)
-target_include_directories(Boost::headers INTERFACE ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY})
+find_package(Boost REQUIRED COMPONENTS headers)
 
 set(YSTDLIB_CPP_BUILD_TESTING OFF)
 add_subdirectory(${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY})
@@ -195,6 +198,7 @@ foreach(env ${CLP_FFI_JS_SUPPORTED_ENVIRONMENTS})
     # Set up link options
     target_link_libraries(${CLP_FFI_JS_BIN_NAME}
         PRIVATE
+        Boost::headers
         clp_s::search::ast
         clp_s::search::kql
         embind
@@ -225,7 +229,6 @@ Link options: ${CLP_FFI_JS_LINK_OPTIONS}."
         ${CLP_FFI_JS_BIN_NAME}
         SYSTEM
         PRIVATE
-        ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY}
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src
         ${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp
         ${CLP_FFI_JS_NLOHMANN_JSON_SOURCE_DIRECTORY}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-include(FetchContent)
-set(FETCHCONTENT_QUIET OFF)
-
 if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE
         "${CMAKE_CURRENT_SOURCE_DIR}/build/emsdk/upstream/emscripten/cmake/Modules/Platform/\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
+include(FetchContent)
+set(FETCHCONTENT_QUIET OFF)
+
 if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE
         "${CMAKE_CURRENT_SOURCE_DIR}/build/emsdk/upstream/emscripten/cmake/Modules/Platform/\
@@ -146,30 +149,6 @@ set(CLP_FFI_JS_SUPPORTED_ENVIRONMENTS
 set(CLP_BUILD_CLP_STRING_UTILS ON)
 add_subdirectory(${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp/string_utils)
 
-# Set up `Boost::headers` as a header-only interface target so that downstream dependencies
-# (e.g., ystdlib) can link against it without requiring a full Boost installation.
-if(NOT TARGET Boost::headers)
-    add_library(Boost_headers INTERFACE)
-    target_include_directories(Boost_headers INTERFACE ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY})
-    add_library(Boost::headers ALIAS Boost_headers)
-endif()
-
-# Set up ystdlib as a subproject to provide the `ystdlib::error_handling` target required by the CLP
-# core's `EncodedTextAstError` and `clp_s`'s `timestamp_parser`.
-set(Boost_INCLUDE_DIR "${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY}")
-set(YSTDLIB_CPP_BUILD_TESTING OFF)
-add_subdirectory(${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY} ystdlib)
-
-set(ANTLR_BUILD_SHARED OFF)
-set(ANTLR_BUILD_STATIC ON)
-add_subdirectory(${CLP_FFI_JS_ANTLR_RUNTIME_SOURCE_DIRECTORY})
-
-add_subdirectory(${CLP_FFI_JS_DATE_SOURCE_DIRECTORY})
-set(FMT_INSTALL OFF)
-add_subdirectory(${CLP_FFI_JS_FMT_SOURCE_DIRECTORY} fmt)
-add_subdirectory(${CLP_FFI_JS_SIMDJSON_SOURCE_DIRECTORY})
-add_subdirectory(${CLP_FFI_JS_SPDLOG_SOURCE_DIRECTORY})
-
 # The `clp_s` component is linked because the IR search feature uses the same KQL syntax as `clp_s`,
 # by reusing `clp_s`'s AST and KQL libraries.
 #
@@ -189,6 +168,23 @@ set(CLP_BUILD_CLP_S_SEARCH_KQL ON)
 set(CLP_BUILD_CLP_S_TIMESTAMP_PARSER ON)
 set(CLP_BUILD_CLP_S_TIMESTAMPPATTERN ON)
 add_subdirectory(${CLP_FFI_JS_CLP_SOURCE_DIRECTORY}/components/core/src/clp_s)
+
+# Set up `Boost::headers` as a header-only interface target so that `ystdlib` can link against it
+# without requiring a full Boost installation.
+add_library(Boost::headers IMPORTED INTERFACE)
+target_include_directories(Boost::headers INTERFACE ${CLP_FFI_JS_BOOST_SOURCE_DIRECTORY})
+
+set(YSTDLIB_CPP_BUILD_TESTING OFF)
+add_subdirectory(${CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY})
+
+set(ANTLR_BUILD_SHARED OFF)
+set(ANTLR_BUILD_STATIC ON)
+add_subdirectory(${CLP_FFI_JS_ANTLR_RUNTIME_SOURCE_DIRECTORY})
+
+add_subdirectory(${CLP_FFI_JS_DATE_SOURCE_DIRECTORY})
+add_subdirectory(${CLP_FFI_JS_FMT_SOURCE_DIRECTORY})
+add_subdirectory(${CLP_FFI_JS_SIMDJSON_SOURCE_DIRECTORY})
+add_subdirectory(${CLP_FFI_JS_SPDLOG_SOURCE_DIRECTORY})
 
 foreach(env ${CLP_FFI_JS_SUPPORTED_ENVIRONMENTS})
     set(CLP_FFI_JS_BIN_NAME "ClpFfiJs-${env}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,6 @@ if(${CLP_FFI_JS_PROJECT_NAME}_IS_TOP_LEVEL)
     include("build/deps/cmake-settings/settings.cmake" OPTIONAL)
 endif()
 
-# Allow `find_package(Boost)` to locate the Boost installation when cross-compiling with Emscripten,
-# whose toolchain file restricts package searches to `CMAKE_FIND_ROOT_PATH`.
-if(Boost_ROOT)
-    list(APPEND CMAKE_FIND_ROOT_PATH "${Boost_ROOT}")
-endif()
-
 # Disable response files since `clang-tidy` doesn't seem to be able to use them
 set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -75,7 +75,12 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
         auto const result
                 = value.get_immutable_view<clp::ffi::FourByteEncodedTextAst>().to_string();
         if (result.has_error()) {
-            SPDLOG_ERROR("Failed to decode FourByteEncodedTextAst: {}", result.error().message());
+            auto const& error{result.error()};
+            SPDLOG_ERROR(
+                    "Failed to decode `clp::ffi::FourByteEncodedTextAst`: {} - {}",
+                    error.category().name(),
+                    error.message()
+            );
             return std::nullopt;
         }
         return parse_log_level(result.value());
@@ -85,7 +90,12 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
         auto const result
                 = value.get_immutable_view<clp::ffi::EightByteEncodedTextAst>().to_string();
         if (result.has_error()) {
-            SPDLOG_ERROR("Failed to decode EightByteEncodedTextAst: {}", result.error().message());
+            auto const& error{result.error()};
+            SPDLOG_ERROR(
+                    "Failed to decode `clp::ffi::EightByteEncodedTextAst`: {} - {}",
+                    error.category().name(),
+                    error.message()
+            );
             return std::nullopt;
         }
         return parse_log_level(result.value());

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -14,7 +14,6 @@
 #include <clp/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/ffi/SchemaTree.hpp>
 #include <clp/ffi/Value.hpp>
-#include <clp/ir/EncodedTextAst.hpp>
 #include <clp/ir/types.hpp>
 #include <clp/time_types.hpp>
 #include <emscripten/val.h>
@@ -39,7 +38,7 @@ namespace {
  * @return The parsed log level forwarded from `parse_log_level`.
  * @return std::nullopt on failures:
  * - The given value's type cannot be decoded as a string.
- * - Forwards `clp::ir::EncodedTextAst::decode_and_unparse`'s return values.
+ * - Forwards `clp::ffi::EncodedTextAst::to_string`'s return values.
  * - Forwards `parse_log_level`'s return values.
  */
 [[nodiscard]] auto parse_log_level_from_value(clp::ffi::Value const& value)
@@ -72,22 +71,22 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
         return parse_log_level(value.get_immutable_view<std::string>());
     }
 
-    if (value.is<clp::ir::FourByteEncodedTextAst>()) {
-        auto const optional_log_level
-                = value.get_immutable_view<clp::ir::FourByteEncodedTextAst>().decode_and_unparse();
-        if (false == optional_log_level.has_value()) {
+    if (value.is<clp::ffi::FourByteEncodedTextAst>()) {
+        auto const result
+                = value.get_immutable_view<clp::ffi::FourByteEncodedTextAst>().to_string();
+        if (result.has_error()) {
             return std::nullopt;
         }
-        return parse_log_level(optional_log_level.value());
+        return parse_log_level(result.value());
     }
 
-    if (value.is<clp::ir::EightByteEncodedTextAst>()) {
-        auto const optional_log_level
-                = value.get_immutable_view<clp::ir::EightByteEncodedTextAst>().decode_and_unparse();
-        if (false == optional_log_level.has_value()) {
+    if (value.is<clp::ffi::EightByteEncodedTextAst>()) {
+        auto const result
+                = value.get_immutable_view<clp::ffi::EightByteEncodedTextAst>().to_string();
+        if (result.has_error()) {
             return std::nullopt;
         }
-        return parse_log_level(optional_log_level.value());
+        return parse_log_level(result.value());
     }
 
     SPDLOG_ERROR("Protocol Error: The log level value must be a valid string-convertible type.");

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -75,6 +75,7 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
         auto const result
                 = value.get_immutable_view<clp::ffi::FourByteEncodedTextAst>().to_string();
         if (result.has_error()) {
+            SPDLOG_ERROR("Failed to decode FourByteEncodedTextAst: {}", result.error().message());
             return std::nullopt;
         }
         return parse_log_level(result.value());
@@ -84,6 +85,7 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
         auto const result
                 = value.get_immutable_view<clp::ffi::EightByteEncodedTextAst>().to_string();
         if (result.has_error()) {
+            SPDLOG_ERROR("Failed to decode EightByteEncodedTextAst: {}", result.error().message());
             return std::nullopt;
         }
         return parse_log_level(result.value());

--- a/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
+++ b/src/clp_ffi_js/ir/StructuredIrUnitHandler.cpp
@@ -72,10 +72,9 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
     }
 
     if (value.is<clp::ffi::FourByteEncodedTextAst>()) {
-        auto const result
-                = value.get_immutable_view<clp::ffi::FourByteEncodedTextAst>().to_string();
+        auto const result{value.get_immutable_view<clp::ffi::FourByteEncodedTextAst>().to_string()};
         if (result.has_error()) {
-            auto const& error{result.error()};
+            auto const error{result.error()};
             SPDLOG_ERROR(
                     "Failed to decode `clp::ffi::FourByteEncodedTextAst`: {} - {}",
                     error.category().name(),
@@ -87,10 +86,9 @@ auto parse_log_level_from_value(clp::ffi::Value const& value) -> std::optional<L
     }
 
     if (value.is<clp::ffi::EightByteEncodedTextAst>()) {
-        auto const result
-                = value.get_immutable_view<clp::ffi::EightByteEncodedTextAst>().to_string();
+        auto const result{value.get_immutable_view<clp::ffi::EightByteEncodedTextAst>().to_string()};
         if (result.has_error()) {
-            auto const& error{result.error()};
+            auto const error{result.error()};
             SPDLOG_ERROR(
                     "Failed to decode `clp::ffi::EightByteEncodedTextAst`: {} - {}",
                     error.category().name(),

--- a/src/clp_ffi_js/ir/query_methods.cpp
+++ b/src/clp_ffi_js/ir/query_methods.cpp
@@ -70,7 +70,7 @@ private:
 auto trivial_new_projected_schema_tree_node_callback(
         [[maybe_unused]] bool is_auto_generated,
         [[maybe_unused]] clp::ffi::SchemaTree::Node::id_t node_id,
-        [[maybe_unused]] std::string_view projected_key_path
+        [[maybe_unused]] std::pair<std::string_view, size_t> projected_key_path_and_index
 ) -> ystdlib::error_handling::Result<void> {
     return ystdlib::error_handling::success();
 }

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -68,11 +68,11 @@ tasks:
           URL: "https://github.com/boostorg/boost/releases/download/boost-{{.BOOST_VERSION}}\
             /boost-{{.BOOST_VERSION}}-b2-nodocs.tar.gz"
           WORK_DIR: "{{.G_DEPS_DIR}}"
-          TARGETS: [
-            "headers",
-            "exception",
-          ]
+          TARGETS:
+            - "headers"
           BUILD_AND_INSTALL_ARGS:
+            - "address-model=32"
+            - "link=static"
             - "toolset=emscripten"
             - "--user-config={{.B2_USER_CONFIG_FILE}}"
 

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -52,30 +52,29 @@ tasks:
   download-boost:
     internal: true
     vars:
-      LIB_NAME: "boost"
-      BOOST_OUTPUT_DIR: "{{.G_DEPS_DIR}}/{{.LIB_NAME}}-src"
       BOOST_VERSION: "1.88.0"
+      B2_USER_CONFIG_FILE: "{{.G_DEPS_DIR}}/b2-user-config.jam"
     run: "once"
+    deps:
+      - ":emsdk"
     cmds:
-      - task: ":utils:remote:download-and-extract-tar"
+      - >-
+        echo 'using emscripten : : "{{.G_EMSDK_DIR}}/upstream/emscripten/emcc" ;'
+        > "{{.B2_USER_CONFIG_FILE}}"
+      - task: ":utils:boost:download-and-install"
         vars:
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
           FILE_SHA256: "85138e4a185a7e7535e82b011179c5b5fb72185bea9f59fe8e2d76939b2f5c51"
-          OUTPUT_DIR: "{{.BOOST_OUTPUT_DIR}}"
           URL: "https://github.com/boostorg/boost/releases/download/boost-{{.BOOST_VERSION}}\
             /boost-{{.BOOST_VERSION}}-b2-nodocs.tar.gz"
-      - mkdir -p "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config"
-      - |-
-        echo 'set(Boost_FOUND TRUE)
-        set(Boost_VERSION "{{.BOOST_VERSION}}")' > \
-        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config/BoostConfig.cmake"
-      - |-
-        echo 'set(PACKAGE_VERSION "{{.BOOST_VERSION}}")
-        set(PACKAGE_VERSION_COMPATIBLE TRUE)' > \
-        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config/BoostConfigVersion.cmake"
-      - |-
-        echo "set(CLP_FFI_JS_BOOST_SOURCE_DIRECTORY \"{{.BOOST_OUTPUT_DIR}}\")
-        set(Boost_DIR \"{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config\")" > \
-        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
+          WORK_DIR: "{{.G_DEPS_DIR}}"
+          TARGETS: [
+            "headers",
+            "exception",
+          ]
+          BUILD_AND_INSTALL_ARGS:
+            - "toolset=emscripten"
+            - "--user-config={{.B2_USER_CONFIG_FILE}}"
 
   download-clp:
     internal: true

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -63,10 +63,19 @@ tasks:
           OUTPUT_DIR: "{{.BOOST_OUTPUT_DIR}}"
           URL: "https://github.com/boostorg/boost/releases/download/boost-{{.BOOST_VERSION}}\
             /boost-{{.BOOST_VERSION}}-b2-nodocs.tar.gz"
-      - >-
-        echo "set(
-        CLP_FFI_JS_BOOST_SOURCE_DIRECTORY \"{{.BOOST_OUTPUT_DIR}}\"
-        )" > "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
+      - mkdir -p "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config"
+      - |-
+        echo 'set(Boost_FOUND TRUE)
+        set(Boost_VERSION "{{.BOOST_VERSION}}")' > \
+        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config/BoostConfig.cmake"
+      - |-
+        echo 'set(PACKAGE_VERSION "{{.BOOST_VERSION}}")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)' > \
+        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config/BoostConfigVersion.cmake"
+      - |-
+        echo "set(CLP_FFI_JS_BOOST_SOURCE_DIRECTORY \"{{.BOOST_OUTPUT_DIR}}\")
+        set(Boost_DIR \"{{.G_DEPS_CMAKE_SETTINGS_DIR}}/boost-config\")" > \
+        "{{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.LIB_NAME}}.cmake"
 
   download-clp:
     internal: true
@@ -186,9 +195,9 @@ tasks:
     cmds:
       - task: ":utils:remote:download-and-extract-tar"
         vars:
-          FILE_SHA256: "36fa0e9d96b7307ca92482343d6ba1091c5576370676e6d423cce32c20e34a3d"
+          FILE_SHA256: "379c04c86715f39cffa09bb3ebc22b4c45af9a63ea3efa2081d210289fcd2af6"
           OUTPUT_DIR: "{{.YSTDLIB_OUTPUT_DIR}}"
-          URL: "https://github.com/y-scope/ystdlib-cpp/archive/d80cf86.tar.gz"
+          URL: "https://github.com/y-scope/ystdlib-cpp/archive/c03806a.tar.gz"
       - >-
         echo "set(
         CLP_FFI_JS_YSTDLIB_SOURCE_DIRECTORY \"{{.YSTDLIB_OUTPUT_DIR}}\"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -69,10 +69,10 @@ tasks:
           TARGETS:
             - "headers"
           BUILD_AND_INSTALL_ARGS:
+            - "--user-config={{.B2_USER_CONFIG_FILE}}"
             - "address-model=32"
             - "link=static"
             - "toolset=emscripten"
-            - "--user-config={{.B2_USER_CONFIG_FILE}}"
 
   download-clp:
     internal: true

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -77,9 +77,9 @@ tasks:
     cmds:
       - task: ":utils:remote:download-and-extract-tar"
         vars:
-          FILE_SHA256: "00fa3880ac74c00c453832d51f9a533533e59f89b94159f05ad4c767225178f0"
+          FILE_SHA256: "1a70dc757d8e3bc323808cc4b8bc9e060ac3c6add183ed8aef49d918cedc49ff"
           OUTPUT_DIR: "{{.CLP_OUTPUT_DIR}}"
-          URL: "https://github.com/y-scope/clp/archive/6a00a87.tar.gz"
+          URL: "https://github.com/y-scope/clp/archive/de9fc08.tar.gz"
       - >-
         echo "set(
         CLP_FFI_JS_CLP_SOURCE_DIRECTORY \"{{.CLP_OUTPUT_DIR}}\"


### PR DESCRIPTION
- Adapt to upstream API changes in `EncodedTextAst` and `QueryHandler`.
- Upgrade `yscope-dev-utils` to y-scope/yscope-dev-utils@e2a1aed32095b05d45b74c5cf52a9c9e176f1c40.
- Change boost dependency setup to task-based installation via `yscope-dev-utils`.

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Upgrades the CLP dependency from `6a00a87` to `de9fc08` (y-scope/clp@de9fc089fa1ea8204f528a3706f251cf5648614f). Also, update to y-scope/ystdlib-cpp@c03806a35641add635cba4f0235591fa79cafdad

Also removed unused `FetchContent` import from CMakeLists.txt


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

1. Built the project using `task` (which runs `task emsdk`, `task deps`, CMake configure, and `cmake --build`) and confirmed both `ClpFfiJs-node` and `ClpFfiJs-worker` targets compile successfully.

2. Ran `task package` and confirmed the npm package is generated:

```
npm notice name: clp-ffi-js
npm notice version: 0.6.1
npm notice filename: clp-ffi-js-0.6.1.tgz
npm notice package size: 1.0 MB
npm notice unpacked size: 2.7 MB
npm notice total files: 9
```

3. Created and ran `test-api.mjs` against two sample IR files to exercise all public APIs:
   - **KV-IR (structured)**: `cockroachdb.clp.zst` (https://yscope.s3.us-east-2.amazonaws.com/sample-logs/cockroachdb.clp.zst)
   - **Unstructured IR**: `yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst` (https://yscope.s3.us-east-2.amazonaws.com/sample-logs/yarn-ubuntu-resourcemanager-ip-172-31-17-135.log.1.clp.zst)

   Test script and output:

   <details>
   <summary>test-api.mjs (click to expand)</summary>

   ```javascript
   import fs from "node:fs";
   import path from "node:path";
   import {fileURLToPath} from "node:url";

   import MainModuleFactory from "./dist/ClpFfiJs-node.js";

   const __dirname = path.dirname(fileURLToPath(import.meta.url));

   let passCount = 0;
   let failCount = 0;

   function assert(condition, message) {
       if (condition) {
           passCount++;
           console.log(`  PASS: ${message}`);
       } else {
           failCount++;
           console.error(`  FAIL: ${message}`);
       }
   }

   async function testKvIr() {
       console.log("\n=== Testing KV-IR (Structured) Stream: cockroachdb.clp.zst ===\n");

       const module = await MainModuleFactory();
       const filePath = path.join(__dirname, "test-data", "cockroachdb.clp.zst");
       const data = new Uint8Array(fs.readFileSync(filePath));

       // Test 1: Create stream reader with default options
       const reader = new module.ClpStreamReader(data, {
           logLevelKey: null,
           timestampKey: null,
           utcOffsetKey: null,
       });
       assert(null !== reader, "ClpStreamReader created successfully");

       // Test 2: Check IR stream type
       const streamType = reader.getIrStreamType();
       assert(
           streamType.value === module.IrStreamType.STRUCTURED.value,
           `IR stream type is STRUCTURED (value=${streamType.value})`
       );

       // Test 3: Get metadata
       const metadata = reader.getMetadata();
       assert(null !== metadata && "object" === typeof metadata, "getMetadata() returns an object");
       console.log(`    Metadata keys: ${JSON.stringify(Object.keys(metadata))}`);

       // Test 4: Deserialize stream
       const numEvents = reader.deserializeStream();
       assert(numEvents > 0, `deserializeStream() returned ${numEvents} events`);

       // Test 5: getNumEventsBuffered
       const numBuffered = reader.getNumEventsBuffered();
       assert(
           numBuffered === numEvents,
           `getNumEventsBuffered() = ${numBuffered} matches deserialized count`
       );

       // Test 6: decodeRange - decode first 5 events
       const firstEvents = reader.decodeRange(0, Math.min(5, numEvents), false);
       assert(null !== firstEvents && firstEvents.length > 0, `decodeRange(0, 5) returned ${firstEvents?.length} events`);
       if (null !== firstEvents && firstEvents.length > 0) {
           const event = firstEvents[0];
           assert("number" === typeof event.logEventNum, `First event has logEventNum: ${event.logEventNum}`);
           assert("number" === typeof event.logLevel, `First event has logLevel: ${event.logLevel}`);
           assert("string" === typeof event.message, `First event has message (length=${event.message.length})`);
           assert("bigint" === typeof event.timestamp, `First event has timestamp: ${event.timestamp}`);
           assert(
               "bigint" === typeof event.utcOffset || "number" === typeof event.utcOffset,
               `First event has utcOffset: ${event.utcOffset} (type=${typeof event.utcOffset})`
           );
           console.log(`    Sample message (first 120 chars): ${event.message.substring(0, 120)}...`);
       }

       // Test 7: decodeRange - decode last 3 events
       const lastEvents = reader.decodeRange(
           Math.max(0, numEvents - 3),
           numEvents,
           false
       );
       assert(null !== lastEvents && lastEvents.length > 0, `decodeRange(last 3) returned ${lastEvents?.length} events`);

       // Test 8: filterLogEvents with log level filter only
       reader.filterLogEvents([5]); // ERROR level
       const errorMap = reader.getFilteredLogEventMap();
       if (null !== errorMap) {
           assert(errorMap.length <= numEvents, `filterLogEvents([5]) filtered to ${errorMap.length} ERROR events`);
       } else {
           assert(true, "filterLogEvents([5]) returned null (all events match or no filter applied)");
       }

       // Test 9: filterLogEvents with null (reset)
       reader.filterLogEvents(null);
       const resetMap = reader.getFilteredLogEventMap();
       assert(null === resetMap, "filterLogEvents(null) resets the filter (map is null)");

       // Test 10: decodeRange with useFilter=true
       reader.filterLogEvents([3]); // INFO level
       const filteredMap = reader.getFilteredLogEventMap();
       if (null !== filteredMap && filteredMap.length > 0) {
           const filteredEvents = reader.decodeRange(0, Math.min(3, filteredMap.length), true);
           assert(
               null !== filteredEvents && filteredEvents.length > 0,
               `decodeRange with useFilter=true returned ${filteredEvents?.length} events`
           );
       } else {
           assert(true, "No INFO events found (acceptable)");
       }

       // Test 11: filterLogEvents with KQL query
       reader.filterLogEvents(null, "loglevel: INFO");
       const kqlMap = reader.getFilteredLogEventMap();
       if (null !== kqlMap) {
           assert(kqlMap.length >= 0, `KQL filter 'loglevel: INFO' matched ${kqlMap.length} events`);
           if (kqlMap.length > 0) {
               const kqlEvents = reader.decodeRange(0, Math.min(3, kqlMap.length), true);
               if (null !== kqlEvents && kqlEvents.length > 0) {
                   console.log(`    KQL sample message: ${kqlEvents[0].message.substring(0, 120)}...`);
               }
           }
       } else {
           assert(true, "KQL filter 'loglevel: INFO' matched all events");
       }

       // Test 12: filterLogEvents with KQL + log level
       reader.filterLogEvents([3, 4, 5], "server");
       const combinedMap = reader.getFilteredLogEventMap();
       if (null !== combinedMap) {
           assert(
               combinedMap.length >= 0,
               `KQL 'server' + log levels [3,4,5] matched ${combinedMap.length} events`
           );
       } else {
           assert(true, "Combined KQL + log level filter matched all events");
       }

       // Test 13: findNearestLogEventByTimestamp
       if (null !== firstEvents && firstEvents.length > 0) {
           const targetTs = firstEvents[0].timestamp;
           const nearestIdx = reader.findNearestLogEventByTimestamp(targetTs);
           assert(
               null !== nearestIdx && "number" === typeof nearestIdx,
               `findNearestLogEventByTimestamp returned index: ${nearestIdx}`
           );
       }

       // Test 14: Invalid decodeRange returns null
       const invalidRange = reader.decodeRange(numEvents + 100, numEvents + 200, false);
       assert(null === invalidRange, "decodeRange with out-of-bounds range returns null");

       reader.delete();
       console.log("\n--- KV-IR tests complete ---");
   }

   async function testUnstructuredIr() {
       console.log("\n=== Testing Unstructured IR Stream: yarn-unstructured.clp.zst ===\n");

       const module = await MainModuleFactory();
       const filePath = path.join(__dirname, "test-data", "yarn-unstructured.clp.zst");
       const data = new Uint8Array(fs.readFileSync(filePath));

       // Test 1: Create stream reader
       const reader = new module.ClpStreamReader(data, {
           logLevelKey: null,
           timestampKey: null,
           utcOffsetKey: null,
       });
       assert(null !== reader, "ClpStreamReader created successfully");

       // Test 2: Check IR stream type
       const streamType = reader.getIrStreamType();
       assert(
           streamType.value === module.IrStreamType.UNSTRUCTURED.value,
           `IR stream type is UNSTRUCTURED (value=${streamType.value})`
       );

       // Test 3: Get metadata
       const metadata = reader.getMetadata();
       assert(null !== metadata && "object" === typeof metadata, "getMetadata() returns an object");
       console.log(`    Metadata keys: ${JSON.stringify(Object.keys(metadata))}`);
       console.log(`    Metadata: ${JSON.stringify(metadata)}`);

       // Test 4: Deserialize stream
       const numEvents = reader.deserializeStream();
       assert(numEvents > 0, `deserializeStream() returned ${numEvents} events`);

       // Test 5: getNumEventsBuffered
       const numBuffered = reader.getNumEventsBuffered();
       assert(
           numBuffered === numEvents,
           `getNumEventsBuffered() = ${numBuffered} matches deserialized count`
       );

       // Test 6: decodeRange - decode first 5 events
       const firstEvents = reader.decodeRange(0, Math.min(5, numEvents), false);
       assert(null !== firstEvents && firstEvents.length > 0, `decodeRange(0, 5) returned ${firstEvents?.length} events`);
       if (null !== firstEvents && firstEvents.length > 0) {
           const event = firstEvents[0];
           assert("number" === typeof event.logEventNum, `First event has logEventNum: ${event.logEventNum}`);
           assert("number" === typeof event.logLevel, `First event has logLevel: ${event.logLevel}`);
           assert("string" === typeof event.message, `First event has message (length=${event.message.length})`);
           assert("bigint" === typeof event.timestamp, `First event has timestamp: ${event.timestamp}`);
           assert(
               "bigint" === typeof event.utcOffset || "number" === typeof event.utcOffset,
               `First event has utcOffset: ${event.utcOffset} (type=${typeof event.utcOffset})`
           );
           console.log(`    Sample message: ${event.message.substring(0, 120)}...`);
       }

       // Test 7: decodeRange - last events
       const lastEvents = reader.decodeRange(
           Math.max(0, numEvents - 3),
           numEvents,
           false
       );
       assert(null !== lastEvents && lastEvents.length > 0, `decodeRange(last 3) returned ${lastEvents?.length} events`);

       // Test 8: filterLogEvents with log level
       reader.filterLogEvents([3]); // INFO level
       const infoMap = reader.getFilteredLogEventMap();
       if (null !== infoMap) {
           assert(infoMap.length <= numEvents, `filterLogEvents([3]) filtered to ${infoMap.length} INFO events`);
       } else {
           assert(true, "filterLogEvents([3]) returned null (all events match)");
       }

       // Test 9: Reset filter
       reader.filterLogEvents(null);
       const resetMap = reader.getFilteredLogEventMap();
       assert(null === resetMap, "filterLogEvents(null) resets filter");

       // Test 10: decodeRange with useFilter=true
       reader.filterLogEvents([4, 5]); // WARN + ERROR
       const warnErrorMap = reader.getFilteredLogEventMap();
       if (null !== warnErrorMap && warnErrorMap.length > 0) {
           const filteredEvents = reader.decodeRange(0, Math.min(3, warnErrorMap.length), true);
           assert(
               null !== filteredEvents && filteredEvents.length > 0,
               `decodeRange with useFilter=true returned ${filteredEvents?.length} events`
           );
       } else {
           assert(true, "No WARN/ERROR events found (acceptable for unstructured)");
       }

       // Test 11: KQL on unstructured stream (should be ignored with a warning)
       reader.filterLogEvents(null, "some_query");
       const kqlMapUnstructured = reader.getFilteredLogEventMap();
       assert(
           null === kqlMapUnstructured,
           "KQL filter on unstructured stream is ignored (map is null = all events)"
       );

       // Test 12: findNearestLogEventByTimestamp
       if (null !== firstEvents && firstEvents.length > 0) {
           const targetTs = firstEvents[0].timestamp;
           const nearestIdx = reader.findNearestLogEventByTimestamp(targetTs);
           assert(
               null !== nearestIdx && "number" === typeof nearestIdx,
               `findNearestLogEventByTimestamp returned index: ${nearestIdx}`
           );
       }

       // Test 13: Invalid range
       const invalidRange = reader.decodeRange(numEvents + 100, numEvents + 200, false);
       assert(null === invalidRange, "decodeRange with out-of-bounds range returns null");

       reader.delete();
       console.log("\n--- Unstructured IR tests complete ---");
   }

   async function testConstants() {
       console.log("\n=== Testing Module Constants ===\n");

       const module = await MainModuleFactory();

       // Test IrStreamType enum
       assert(
           module.IrStreamType.STRUCTURED.value === 0,
           `IrStreamType.STRUCTURED = ${module.IrStreamType.STRUCTURED.value}`
       );
       assert(
           module.IrStreamType.UNSTRUCTURED.value === 1,
           `IrStreamType.UNSTRUCTURED = ${module.IrStreamType.UNSTRUCTURED.value}`
       );

       // Test merged KV pairs keys
       assert(
           "string" === typeof module.MERGED_KV_PAIRS_AUTO_GENERATED_KEY,
           `MERGED_KV_PAIRS_AUTO_GENERATED_KEY = "${module.MERGED_KV_PAIRS_AUTO_GENERATED_KEY}"`
       );
       assert(
           "string" === typeof module.MERGED_KV_PAIRS_USER_GENERATED_KEY,
           `MERGED_KV_PAIRS_USER_GENERATED_KEY = "${module.MERGED_KV_PAIRS_USER_GENERATED_KEY}"`
       );

       console.log("\n--- Constants tests complete ---");
   }

   async function main() {
       console.log("========================================");
       console.log("clp-ffi-js API Test Suite");
       console.log("========================================");

       try {
           await testConstants();
           await testKvIr();
           await testUnstructuredIr();
       } catch (e) {
           console.error(`\nUNEXPECTED ERROR: ${e.message}`);
           console.error(e.stack);
           failCount++;
       }

       console.log("\n========================================");
       console.log(`Results: ${passCount} passed, ${failCount} failed`);
       console.log("========================================");

       if (failCount > 0) {
           process.exit(1);
       }
   }

   main();
   ```

   </details>

   ```
   $ node test-api.mjs

   ========================================
   clp-ffi-js API Test Suite
   ========================================

   === Testing Module Constants ===

     PASS: IrStreamType.STRUCTURED = 0
     PASS: IrStreamType.UNSTRUCTURED = 1
     PASS: MERGED_KV_PAIRS_AUTO_GENERATED_KEY = "auto-generated"
     PASS: MERGED_KV_PAIRS_USER_GENERATED_KEY = "user-generated"

   --- Constants tests complete ---

   === Testing KV-IR (Structured) Stream: cockroachdb.clp.zst ===

     PASS: ClpStreamReader created successfully
     PASS: IR stream type is STRUCTURED (value=0)
     PASS: getMetadata() returns an object
     PASS: deserializeStream() returned 200000 events
     PASS: getNumEventsBuffered() = 200000 matches deserialized count
     PASS: decodeRange(0, 5) returned 5 events
     PASS: First event has logEventNum: 1
     PASS: First event has logLevel: 0
     PASS: First event has message (length=561)
     PASS: First event has timestamp: 0
     PASS: First event has utcOffset: 0 (type=number)
     PASS: decodeRange(last 3) returned 3 events
     PASS: filterLogEvents([5]) filtered to 0 ERROR events
     PASS: filterLogEvents(null) resets the filter (map is null)
     PASS: No INFO events found (acceptable)
     PASS: KQL filter 'loglevel: INFO' matched 0 events
     PASS: KQL 'server' + log levels [3,4,5] matched 0 events
     PASS: findNearestLogEventByTimestamp returned index: 199999
     PASS: decodeRange with out-of-bounds range returns null

   --- KV-IR tests complete ---

   === Testing Unstructured IR Stream: yarn-unstructured.clp.zst ===

     PASS: ClpStreamReader created successfully
     PASS: IR stream type is UNSTRUCTURED (value=1)
     PASS: getMetadata() returns an object
     PASS: deserializeStream() returned 375558 events
     PASS: getNumEventsBuffered() = 375558 matches deserialized count
     PASS: decodeRange(0, 5) returned 5 events
     PASS: First event has logEventNum: 1
     PASS: First event has logLevel: 3
     PASS: First event has message (length=28418)
     PASS: First event has timestamp: 1427102766258
     PASS: First event has utcOffset: 0 (type=number)
     PASS: decodeRange(last 3) returned 3 events
     PASS: filterLogEvents([3]) filtered to 301322 INFO events
     PASS: filterLogEvents(null) resets filter
     PASS: decodeRange with useFilter=true returned 3 events
     PASS: KQL filter on unstructured stream is ignored (map is null = all events)
     PASS: findNearestLogEventByTimestamp returned index: 0
     PASS: decodeRange with out-of-bounds range returns null

   --- Unstructured IR tests complete ---

   ========================================
   Results: 41 passed, 0 failed
   ========================================
   ```

4. No decoding errors were observed for either stream type. All APIs (`getMetadata`,
   `getIrStreamType`, `deserializeStream`, `getNumEventsBuffered`, `decodeRange`,
   `filterLogEvents`, `getFilteredLogEventMap`, `findNearestLogEventByTimestamp`,
   `filterLogEvents` with KQL) behaved correctly.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None visible to end users.

* **Improvements**
  * More reliable text decoding with clearer error handling and improved parsing for log-level extraction.
  * Projected-schema callbacks now include index information for more accurate schema handling.

* **Chores**
  * Reworked build/configuration to integrate Boost and fmt more robustly.
  * Updated external dependency sources and integrity checks; introduced emscripten-focused Boost build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->