### PR TITLE
chore(taskfile): Rename taskfile (resolves #116); Move lint tasks (resolves #117).

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 includes:
   deps: "taskfiles/deps.yaml"
-  lint: "lint-tasks.yml"
+  lint: "taskfiles/lint.yaml"
   test: "taskfiles/test.yaml"
   utils: "tools/yscope-dev-utils/exports/taskfiles/utils/utils.yaml"
 

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -133,7 +133,6 @@ tasks:
           --config-file "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
           --strict \
           .github \
-          taskfiles/lint.yaml \
           taskfiles \
           taskfile.yaml
 

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -133,8 +133,8 @@ tasks:
           --config-file "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
           --strict \
           .github \
-          taskfiles \
-          taskfile.yaml
+          taskfile.yaml \
+          taskfiles
 
   cpp-lint-configs:
     internal: true

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -147,7 +147,7 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
     sources:
-      - "{{.ROOT_DIR}}/taskfile.yaml"
+      - "{{.ROOT_TASKFILE}}"
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -133,9 +133,9 @@ tasks:
           --config-file "{{.ROOT_DIR}}/tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
           --strict \
           .github \
-          lint-tasks.yml \
+          taskfiles/lint.yaml \
           taskfiles \
-          Taskfile.yml
+          taskfile.yaml
 
   cpp-lint-configs:
     internal: true
@@ -148,7 +148,7 @@ tasks:
       CHECKSUM_FILE: "{{.G_BUILD_DIR}}/{{.TASK | replace \":\" \"#\"}}.md5"
       OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
     sources:
-      - "{{.ROOT_DIR}}/Taskfile.yml"
+      - "{{.ROOT_DIR}}/taskfile.yaml"
       - "{{.TASKFILE}}"
       - "lint-requirements.txt"
     generates: ["{{.CHECKSUM_FILE}}"]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

- Rename `Taskfile.yml` to `taskfile.yaml` and update the lint include path.
- Move `lint-tasks.yml` to `taskfiles/lint.yaml` and refresh lint task references.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## Validation Steps

1. Task: Confirm Task discovers the renamed taskfile by default.
   Command: `task --list-all`
   Output:
   ```text
   task: Available tasks for this project:
   * clean:                            
   * clean-clp-ffi-js:                 
   * clean-emsdk:                      
   * clp-ffi-js:                       
   * default:                          
   * emsdk:                            
   * package:                          
   * deps:default:                     Download all dependencies.      (aliases: deps)
   * lint:check:                       
   * lint:check-cpp-diff:              
   * lint:check-cpp-format:            
   * lint:check-cpp-full:              
   * lint:check-cpp-static-diff:             (aliases: lint:fix-cpp-static-diff)
   * lint:check-cpp-static-full:             (aliases: lint:fix-cpp-static-full)
   * lint:check-js:                    
   * lint:check-no-cpp:                
   * lint:fix:                         
   * lint:fix-cpp-diff:                
   * lint:fix-cpp-format:              
   * lint:fix-cpp-full:                
   * lint:fix-js:                      
   * lint:fix-no-cpp:                  
   * lint:yaml:                              (aliases: lint:check-yaml, lint:fix-yaml)
   * test:default:                           (aliases: test)
   * test:js:                          
   ```
   Explanation: Task resolves `taskfile.yaml` by default and loads tasks from included taskfiles (for example, `lint:*` and `test:*` from `taskfiles/lint.yaml` and `taskfiles/test.yaml`).

2. Task: Validate YAML linting resolves the renamed/moved taskfiles.
   Command: `task lint:check-yaml`
   Output:
   ```text
   task: [create-venv-lint] rm -rf '/home/junhao/workspace/clp-ffi-js/build/lint-venv'
   task: [create-venv-lint] python3 -m venv '/home/junhao/workspace/clp-ffi-js/build/lint-venv'
   task: [utils:misc:replace-text] # NOTE:
   # 1. We can't use `sed -i` since `-i` has different syntax on Linux and macOS
   # 2. We can't use `--regexp` instead of `-E` since `--regexp` is not supported on macOS
   src="/home/junhao/workspace/clp-ffi-js/build/lint-venv/bin/activate"
   dst="/home/junhao/workspace/clp-ffi-js/build/lint-venv/bin/activate.tmp"
   sed -E "s/^([[:space:]]*)hash[[:space:]]+.*/\1true/g" "${src}" > "${dst}"
   mv "${dst}" "${src}"
   task: [create-venv-lint] . "/home/junhao/workspace/clp-ffi-js/build/lint-venv/bin/activate"
   pip3 install --upgrade pip
   pip3 install --upgrade -r "lint-requirements.txt"
   Requirement already satisfied: pip in ./build/lint-venv/lib/python3.10/site-packages (22.0.2)
   Collecting pip
     Using cached pip-26.0.1-py3-none-any.whl (1.8 MB)
   Installing collected packages: pip
     Attempting uninstall: pip
       Found existing installation: pip 22.0.2
       Uninstalling pip-22.0.2:
         Successfully uninstalled pip-22.0.2
   Successfully installed pip-26.0.1
   Collecting clang-format>=20.1 (from -r lint-requirements.txt (line 1))
     Using cached clang_format-21.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (4.7 kB)
   Collecting clang-tidy>=20.1 (from -r lint-requirements.txt (line 2))
     Using cached clang_tidy-21.1.6-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (3.7 kB)
   Collecting yamllint>=1.35.1 (from -r lint-requirements.txt (line 3))
     Using cached yamllint-1.38.0-py3-none-any.whl.metadata (4.2 kB)
   Collecting pathspec>=1.0.0 (from yamllint>=1.35.1->-r lint-requirements.txt (line 3))
     Using cached pathspec-1.0.4-py3-none-any.whl.metadata (13 kB)
   Collecting pyyaml (from yamllint>=1.35.1->-r lint-requirements.txt (line 3))
     Using cached pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.4 kB)
   Using cached clang_format-21.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (1.8 MB)
   Using cached clang_tidy-21.1.6-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (40.4 MB)
   Using cached yamllint-1.38.0-py3-none-any.whl (68 kB)
   Using cached pathspec-1.0.4-py3-none-any.whl (55 kB)
   Using cached pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (770 kB)
   Installing collected packages: clang-tidy, clang-format, pyyaml, pathspec, yamllint

   Successfully installed clang-format-21.1.8 clang-tidy-21.1.6 pathspec-1.0.4 pyyaml-6.0.3 yamllint-1.38.0
   task: [lint:yaml] . "/home/junhao/workspace/clp-ffi-js/build/lint-venv/bin/activate"
   yamllint \
     --config-file "/home/junhao/workspace/clp-ffi-js/tools/yscope-dev-utils/exports/lint-configs/.yamllint.yml" \
     --strict \
     .github \
     taskfiles/lint.yaml \
     taskfiles \
     taskfile.yaml
   ```
   Explanation: `yamllint` runs against the renamed/moved taskfiles and completes without errors.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized build and lint task configuration and updated internal references to use a new centralized task layout, ensuring consistent task resolution and source referencing across the build system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->