### PR TITLE
fix(publish-to-npm): Upgrade npm for OIDC; Add prerelease dist-tag handling.

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"
-      # Required for OIDC trusted publishing and the `--provenance` flag in `npm publish`.
+      # Required for OIDC trusted publishing.
       id-token: "write"
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
@@ -51,4 +51,25 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org/"
 
-      - run: "npm publish --provenance"
+      # Trusted publishing requires npm >= 11.5.1 for OIDC token exchange.
+      - name: "Install npm with OIDC trusted publishing support"
+        run: "npm install --global npm@^11.12.0"
+
+      # Determine the `dist-tag` for npm publish: use the prerelease identifier
+      # (e.g., "beta" from "1.0.0-beta.1") or "latest" for stable versions.
+      - name: "Determine npm distribution tag"
+        id: "dist-tag"
+        run: |
+          TAG=$(
+            jq -r '
+              .version
+              | split("-")
+              | if length > 1
+                then (.[1] | split(".")[0])
+                else "latest"
+                end
+            ' package.json
+          )
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+      - run: "npm publish --tag ${{steps.dist-tag.outputs.tag}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Fixes two failures encountered when publishing `clp-ffi-js@0.7.0-beta.1` via the
`publish-to-npm` workflow.

**Issue 1 – Bundled npm too old to support OIDC trusted publishing**

The bundled npm on the GitHub Actions runner is too old to support OIDC trusted publishing
natively (requires npm ≥ 11.5.1). The fix is to add a step to install npm `^11.12.0`, and
drop the `--provenance` flag — provenance attestation is generated automatically by trusted
publishing and does not need to be requested explicitly.

**Issue 2 – Prerelease version rejected without an explicit `--tag`**

npm ≥ 11 enforces that prerelease versions (e.g. `0.7.0-beta.1`) must be published with an
explicit `--tag` to prevent a prerelease from accidentally becoming the `latest` dist-tag. A new
"Determine npm distribution tag" step uses `jq` to extract the prerelease identifier
(e.g. `beta`) from `package.json`'s version field, defaulting to `latest` for stable releases.

## Changes

Updated `publish-to-npm.yaml`:
- Updated the `id-token` permission comment (removed stale reference to `--provenance`).
- Added "Install npm with OIDC trusted publishing support" step (`npm@^11.12.0`).
- Added "Determine npm distribution tag" step to dynamically derive the dist-tag via `jq`.
- Replaced `npm publish --provenance` with `npm publish --tag <dist-tag>`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

## 1. Verify dist-tag extraction for a prerelease version

**Task**: Confirm that `jq` correctly extracts `beta` from a `0.7.0-beta.1` version string.

**Command**:
```bash
echo '{"version": "0.7.0-beta.1"}' | jq -r '
  .version
  | split("-")
  | if length > 1
    then (.[1] | split(".")[0])
    else "latest"
    end'
```

**Output**:
```
beta
```

## 2. Verify dist-tag extraction for a stable version

**Task**: Confirm that `jq` correctly falls back to `latest` for a stable version string.

**Command**:
```bash
echo '{"version": "0.6.1"}' | jq -r '
  .version
  | split("-")
  | if length > 1
    then (.[1] | split(".")[0])
    else "latest"
    end'
```

**Output**:
```
latest
```

## 3. Successful publish CI run

After both fixes were applied, the `publish-to-npm` workflow completed successfully:

https://github.com/y-scope/clp-ffi-js/actions/runs/23287725360

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated package publishing workflow to compute and apply distribution tags dynamically based on package versions.
  * Enhanced npm infrastructure requirements for the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->