### PR TITLE
fix(ci): Replace `npm install -g @go-task/cli` with `go-task/setup-task` action to eliminate npm supply-chain risk; Use reusable CI actions from `yscope-dev-utils`; Bump `actions/checkout` to v6.0.2.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ on:
       - "src/**/*.ts"
       - "taskfile.yaml"
       - "taskfiles/**"
-      - "tools/yscope-dev-utils/**"
+      - "tools/yscope-dev-utils"
       - "typedoc.json"
   push:
     paths: *monitored_paths

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,8 @@ on:
       - "package.json"
       - "src/**/*.ts"
       - "taskfile.yaml"
-      - "taskfiles/docs.yaml"
+      - "taskfiles/**"
+      - "tools/yscope-dev-utils/**"
       - "typedoc.json"
   push:
     paths: *monitored_paths
@@ -40,6 +41,8 @@ jobs:
 
       - name: "Install task"
         uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 
       - name: "Build docs"
         run: "task docs:site"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,9 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.48.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
       - "package.json"
       - "src/**/*.ts"
       - "taskfile.yaml"
-      - "taskfiles/**/*"
+      - "taskfiles/**"
       - "tools/yscope-dev-utils"
       - "typedoc.json"
   push:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,13 +39,7 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
-
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - name: "Build docs"
         run: "task docs:site"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,7 +8,7 @@ on:
       - "package.json"
       - "src/**/*.ts"
       - "taskfile.yaml"
-      - "taskfiles/**"
+      - "taskfiles/**/*"
       - "tools/yscope-dev-utils"
       - "typedoc.json"
   push:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,8 +39,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Install task"
-        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,18 +23,12 @@ jobs:
         os: ["macos-latest", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 
       - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
-
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - name: "Lint .cpp files (format only)"
         run: "task lint:check-cpp-format"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,8 @@ jobs:
       - name: "Install task"
         uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
+
       - name: "Lint .cpp files (format only)"
         run: "task lint:check-cpp-format"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,8 +27,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Install task"
-        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,9 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.48.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -19,7 +19,9 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        run: "npm install --global @go-task/cli@3.48.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - run: "task package"
 

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -21,6 +21,8 @@ jobs:
       - name: "Install task"
         uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
+
       - run: "task package"
 
       - name: "Upload build artifacts"

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -18,8 +18,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Install task"
-        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -19,9 +19,7 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - run: "task package"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ on:
       - "taskfile.yaml"
       - "taskfiles/**"
       - "test/**"
+      - "tools/yscope-dev-utils/**"
       - "tsconfig.json"
       - "vitest.config.ts"
   push:
@@ -39,13 +40,7 @@ jobs:
       - name: "Install task"
         uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
-      - name: "Log tool versions"
-        run: |-
-          cmake --version
-          md5sum --version
-          node --version
-          npm --version
-          task --version
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 
       - name: "Run JS tests"
         run: "task test:js"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
       - "taskfile.yaml"
       - "taskfiles/**"
       - "test/**"
-      - "tools/yscope-dev-utils/**"
+      - "tools/yscope-dev-utils"
       - "tsconfig.json"
       - "vitest.config.ts"
   push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: "Install task"
-        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,14 +32,12 @@ jobs:
   tests:
     runs-on: "ubuntu-24.04"
     steps:
-      - uses: "actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8"  # v6.0.1
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 
       - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - name: "Log tool versions"
         run: |-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
       - "package.json"
       - "src/**"
       - "taskfile.yaml"
-      - "taskfiles/**/*"
+      - "taskfiles/**"
       - "test/**"
       - "tools/yscope-dev-utils"
       - "tsconfig.json"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,9 @@ jobs:
           submodules: "recursive"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli@3.48.0"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - name: "Log tool versions"
         run: |-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
       - "package.json"
       - "src/**"
       - "taskfile.yaml"
-      - "taskfiles/**"
+      - "taskfiles/**/*"
       - "test/**"
       - "tools/yscope-dev-utils"
       - "tsconfig.json"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ You can use GitHub issues to [request features][feature-req] or [report bugs][bu
 ## Requirements
 * CMake >= 3.16
 * GNU Make
-* Python 3
-* [Task] >= 3.48.0
+* Python >= 3.10
+* [Task] >= 3.49.1
 
 ## Setup
 Initialize and update submodules:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can use GitHub issues to [request features][feature-req] or [report bugs][bu
 ## Requirements
 * CMake >= 3.16
 * GNU Make
-* Python >= 3.10
+* Python 3
 * [Task] >= 3.49.1
 
 ## Setup


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

This PR makes three related CI improvements:

1. **Replace `npm install -g @go-task/cli` with `go-task/setup-task` action.** All CI workflows
   previously installed the Task runner via `npm install -g @go-task/cli`. `@go-task/cli` declares a
   transitive dependency on `axios: ^1.8.2`, and because global npm installs have no lock file, npm
   resolves to whatever the latest semver-compatible version is at install time. During the
   [axios supply-chain compromise on 2026-03-31][axios-advisory], this caused CI runners to pull in
   the malicious `axios@1.14.1` package. This commit replaces all occurrences with the official
   [`go-task/setup-task`][setup-task] GitHub Action, which downloads the Task binary directly from
   GitHub Releases without involving npm.

2. **Use reusable CI actions from `yscope-dev-utils`.** Replace inline `go-task/setup-task` action
   references with the centralized [`install-go-task`][install-go-task] composite action from the
   `yscope-dev-utils` submodule. This also removes standalone `brew install coreutils` steps on
   macOS, since the reusable action handles that internally. The `yscope-dev-utils` submodule is
   updated to [`38bf51e`][dev-utils-commit].

3. **Bump `actions/checkout` to [v6.0.2][checkout-v6.0.2].** Updates remaining `actions/checkout`
   references from `v6.0.1` to `v6.0.2`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. Verified that no `npm install -g` commands remain in any workflow file.
2. Verified that no inline `go-task/setup-task`, `brew install coreutils`, or old
   `actions/checkout` SHA references remain in `.github/workflows/`.
3. Confirmed the `yscope-dev-utils` submodule points to [`38bf51e`][dev-utils-commit].

[axios-advisory]: https://github.com/advisories/GHSA-fw8c-xr5c-95f9
[checkout-v6.0.2]: https://github.com/actions/checkout/releases/tag/v6.0.2
[dev-utils-commit]: https://github.com/y-scope/yscope-dev-utils/commit/38bf51e
[install-go-task]: https://github.com/y-scope/yscope-dev-utils/tree/38bf51e/exports/github/actions/install-go-task
[setup-task]: https://github.com/go-task/setup-task
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized CI task/tool installation by switching to local reusable actions.
  * Replaced ad‑hoc tool-install and version-print steps with unified action invocations.
  * Broadened CI trigger paths to include additional taskfiles and tooling directories.
  * Updated pinned CI actions and tooling submodule references to newer commits for consistency.

* **Documentation**
  * Clarified requirements: raised minimum Python and task-runner version requirements in README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->