### PR TITLE
fix(publish-to-npm): Install npm 11.12.1 via Corepack to work around npm/cli#9151.

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -53,7 +53,9 @@ jobs:
 
       # Trusted publishing requires npm >= 11.5.1 for OIDC token exchange.
       - name: "Install npm with OIDC trusted publishing support"
-        run: "npm install --global npm@^11.12.0"
+        run: |-
+          corepack enable npm
+          corepack prepare npm@11.12.1 --activate
 
       # Determine the `dist-tag` for npm publish: use the prerelease identifier
       # (e.g., "beta" from "1.0.0-beta.1") or "latest" for stable versions.

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -51,11 +51,12 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org/"
 
-      # Trusted publishing requires npm >= 11.5.1 for OIDC token exchange.
+      # Trusted publishing requires npm >= 11.5.1 for OIDC token exchange. The exact version is
+      # pinned via the `packageManager` field in `package.json`.
       - name: "Install npm with OIDC trusted publishing support"
         run: |-
           corepack enable npm
-          corepack prepare npm@11.12.1 --activate
+          corepack install
 
       # Determine the `dist-tag` for npm publish: use the prerelease identifier
       # (e.g., "beta" from "1.0.0-beta.1") or "latest" for stable versions.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:init": "PLAYWRIGHT_BROWSERS_PATH=0 npm exec playwright -- install --with-deps",
     "test": "PLAYWRIGHT_BROWSERS_PATH=0 vitest run"
   },
+  "packageManager": "npm@11.12.1",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 MD013 -->

# Description

The `publish-to-npm` workflow started failing on every `v0.7.0-beta.2` release attempt at the "Install npm with OIDC trusted publishing support" step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
...
```

(Run: https://github.com/y-scope/clp-ffi-js/actions/runs/24210962207.)

This is [npm/cli#9151][npm-cli-9151] — the `npm@10.9.7` bundled with the current `actions/setup-node@v6.3.0` / Node 22.22.2 image has a broken dependency tree and cannot run `npm install -g npm` against itself, so the existing step (`npm install --global npm@^11.12.0`, added in #136 to raise npm above the OIDC trusted-publishing threshold of `11.5.1`) can no longer bootstrap.

The `npm install --global npm` approach has been brittle beyond npm/cli#9151 — it also pulls transitive dependencies with no lock file (the same pattern that motivated #142). This PR replaces it with [Corepack][corepack], which downloads the pinned npm tarball directly from the registry without running through the bundled npm at all. The version is declared once in `package.json`'s `packageManager` field, and the workflow runs `corepack install` (no arguments) to fetch the pinned tarball — Corepack then resolves the version from `package.json` on every subsequent `npm` invocation under the project root, keeping `package.json` as the single source of truth. Note that `corepack enable` (without arguments) does not install an npm shim — npm has to be named explicitly (see [nodejs/corepack#347][corepack-347]) — so the step uses `corepack enable npm` followed by `corepack install`.

## Changes

- https://github.com/y-scope/clp-ffi-js/blob/1b142ee1937267ebd1d348b3bececd2d6dd100b0/.github/workflows/publish-to-npm.yaml#L56-L59 — replaced `run: "npm install --global npm@^11.12.0"` with a multi-line `run:` block that invokes `corepack enable npm` followed by `corepack install`. The latter reads the pinned version from `package.json`'s `packageManager` field, so the workflow has no hard-coded version.
- https://github.com/y-scope/clp-ffi-js/blob/1b142ee1937267ebd1d348b3bececd2d6dd100b0/package.json#L29 — added `"packageManager": "npm@11.12.1"` as the single source of truth for the pinned npm version.

# Impact assessment

- **Scope**: a single step in `publish-to-npm.yaml` plus a one-line metadata field in `package.json`. The workflow runs only on `release: created` / `workflow_dispatch`; the `packageManager` field is metadata and does not affect package consumers at runtime.
- **Behavior**: identical publish outcome — npm 11.12.1 on the runner, OIDC trusted-publishing token exchange, automatic provenance attestation, same `--tag <dist-tag>` semantics.
- **Risk**: low. The Corepack approach is end-to-end validated by a successful publish on `beta/sfa` (see Validation §2), and §1 verifies the exact `11.12.1` pin locally.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

## 1. Verify `corepack install` resolves the pinned version from `package.json` on a pristine Node 22

**Task**: Confirm that `corepack enable npm && corepack install` reads `"packageManager": "npm@11.12.1"` from `package.json` and produces an `npm` that reports `11.12.1` — without going through the broken `npm install -g npm` code path blocked by npm/cli#9151.

**Command** (run from the project root, where `package.json` lives):
```bash
# Starting state: bundled npm from Node 22
npm --version
readlink "$(which npm)"

corepack enable npm
corepack install

# After: pinned npm via Corepack shim
npm --version
readlink "$(which npm)"
```

**Output**:
```
10.9.4
../lib/node_modules/npm/bin/npm-cli.js
Adding npm@11.12.1 to the cache...
11.12.1
../lib/node_modules/corepack/dist/npm.js
```

**Explanation**: `corepack install` (no args) read the pinned version from `package.json`'s `packageManager` field, fetched the npm tarball, and re-pointed the `npm` shim at Corepack's dispatcher. `npm --version` now reports `11.12.1` — above the `11.5.1` threshold needed for OIDC trusted publishing. No `npm install -g` is ever invoked, so npm/cli#9151 does not apply.

## 2. End-to-end CI publish on `beta/sfa`

**Task**: Confirm the Corepack approach activates pinned npm and completes an OIDC trusted-publish on a real GitHub Actions runner.

**Reference**: https://github.com/y-scope/clp-ffi-js/actions/runs/24220210010 — `v0.7.0-beta.2` `publish-to-npm`, ✓ success.

**Relevant log lines from the `publish-to-npm` job**:
```
Preparing npm@11.12.0 for immediate activation...
...
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1267745722
```

**Explanation**: The Corepack step activated the pinned npm without going through the broken bundled npm, and the subsequent `npm publish` performed an OIDC token exchange and produced a signed provenance statement — proving the Corepack→OIDC workflow path this PR ports to `main` works end to end. That run pinned `11.12.0` via `corepack prepare`; this PR bumps the pin to `11.12.1` and switches to `corepack install` so the version lives in `package.json` as the single source of truth — the activation path Corepack uses internally is unchanged.

[corepack]: https://nodejs.org/api/corepack.html
[corepack-347]: https://github.com/nodejs/corepack/issues/347
[npm-cli-9151]: https://github.com/npm/cli/issues/9151
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package manager configuration to ensure consistent versioning across development and deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->