### PR TITLE
chore(test): Relax test lint constraints and extend Vitest timeout.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,6 @@ const EslintConfig = [
         files: ["test/**/*.ts"],
         rules: {
             "@stylistic/array-element-newline": "off",
-            "dot-notation": "off",
             "jsdoc/require-description": "off",
             "jsdoc/require-returns": "off",
             "max-lines-per-function": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,18 @@ const EslintConfig = [
     CommonConfig,
     ...TsConfigArray,
     ...StylisticConfigArray,
+    {
+        files: ["test/**/*.ts"],
+        rules: {
+            "@stylistic/array-element-newline": "off",
+            "dot-notation": "off",
+            "jsdoc/require-description": "off",
+            "jsdoc/require-returns": "off",
+            "max-lines-per-function": "off",
+            "max-statements": "off",
+            "no-magic-numbers": "off",
+        },
+    },
 ];
 
 

--- a/test/SfaUtils.test.ts
+++ b/test/SfaUtils.test.ts
@@ -36,7 +36,6 @@ describe("SFA utilities", () => {
     it("should reject buffers that don't start with the CLP SFA magic bytes", () => {
         expect(isClpJsonSingleFileArchive(new ArrayBuffer(0))).toBe(false);
 
-        // eslint-disable-next-line @stylistic/array-element-newline, no-magic-numbers
         const nonClp = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
 
         expect(isClpJsonSingleFileArchive(nonClp)).toBe(false);

--- a/test/sfaModule.test.ts
+++ b/test/sfaModule.test.ts
@@ -46,7 +46,6 @@ const createDeferred = <T>(): {
     return {promise, reject, resolve};
 };
 
-// eslint-disable-next-line max-lines-per-function
 describe("sfa/module.ts", () => {
     describe("getModule", () => {
         it("throws if the factory has not been set", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
                     name: "node",
                     include: ["test/**/*.test.ts"],
                     environment: "node",
-                    testTimeout: 30_000,
+                    testTimeout: 300_000,
                 },
             },
             {
@@ -28,7 +28,7 @@ export default defineConfig({
                         ],
                         headless: true,
                     },
-                    testTimeout: 30_000,
+                    testTimeout: 300_000,
                 },
             },
         ],


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

- Add test-only ESLint overrides for rules that are noisy or impractical in fixture-heavy tests.
- Remove stale inline ESLint disable comments now covered by the test override.
- Increase the Vitest timeout from 30 seconds to 5 minutes for both Node and browser test projects

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] `npm run lint:check:js` and `npm run test` pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased test timeouts to reduce the chance of long-running tests failing prematurely.

* **Chores**
  * Updated linting configuration for test files to better match test code patterns.
  * Removed a couple of minor, test-only lint suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->