### PR TITLE
feat(sfa): Add API for decoding all log events.

### DIFF
--- a/src/clp_ffi_js/sfa/ClpArchiveReader.ts
+++ b/src/clp_ffi_js/sfa/ClpArchiveReader.ts
@@ -75,13 +75,7 @@ class ClpArchiveReader {
     decodeAll (): LogEvent[] {
         return this.#getWasmReader()
             .decodeAll()
-            .map((rawEvent) => {
-                return new LogEvent(
-                    rawEvent.logEventIdx,
-                    rawEvent.timestamp,
-                    rawEvent.message
-                );
-            });
+            .map((rawEvent) => new LogEvent(rawEvent));
     }
 
     /**

--- a/src/clp_ffi_js/sfa/ClpArchiveReader.ts
+++ b/src/clp_ffi_js/sfa/ClpArchiveReader.ts
@@ -1,3 +1,4 @@
+import {LogEvent} from "./LogEvent.js";
 import {getModule} from "./module.js";
 import type {FileInfo} from "./types.js";
 
@@ -63,6 +64,24 @@ class ClpArchiveReader {
      */
     getFileInfos (): FileInfo[] {
         return this.#getWasmReader().getFileInfos();
+    }
+
+    /**
+     * Decodes all log events in global log-event-index order.
+     *
+     * @return Decoded log events.
+     * @throws {Error} If the reader has been closed.
+     */
+    decodeAll (): LogEvent[] {
+        return this.#getWasmReader()
+            .decodeAll()
+            .map((rawEvent) => {
+                return new LogEvent(
+                    rawEvent.logEventIdx,
+                    rawEvent.timestamp,
+                    rawEvent.message
+                );
+            });
     }
 
     /**

--- a/src/clp_ffi_js/sfa/LogEvent.ts
+++ b/src/clp_ffi_js/sfa/LogEvent.ts
@@ -1,6 +1,7 @@
 import type {
     JsonObject,
     JsonValue,
+    RawLogEvent,
 } from "./types.js";
 import {isJsonObject} from "./utils.js";
 
@@ -8,47 +9,43 @@ import {isJsonObject} from "./utils.js";
 /**
  * Single log event from a CLP archive.
  */
-class LogEvent {
-    readonly logEventIdx: bigint;
-
-    readonly timestamp: bigint;
-
-    readonly message: string;
+class LogEvent implements RawLogEvent {
+    /**
+     * Global log event index.
+     */
+    declare readonly logEventIdx: bigint;
 
     /**
-     * @param logEventIdx Global log event index.
-     * @param timestamp Epoch timestamp.
-     * @param message Serialized message string.
+     * Epoch timestamp.
      */
-    constructor (logEventIdx: bigint, timestamp: bigint, message: string) {
-        this.logEventIdx = logEventIdx;
-        this.timestamp = timestamp;
-        this.message = message;
+    declare readonly timestamp: bigint;
+
+    /**
+     * Serialized message string.
+     */
+    declare readonly message: string;
+
+    /**
+     * @param rawEvent Raw log event interface returned by the WASM binding.
+     */
+    constructor (rawEvent: RawLogEvent) {
+        Object.assign(this, rawEvent);
     }
 
     /**
-     * Returns the key-value pairs of this log event by parsing the message as JSON.
+     * Parses the serialized message as a JSON object.
      *
-     * @return The key-value pairs, or null if the message is not a JSON object.
+     * @return The parsed object, or null if parsing fails or produces a non-object.
      */
     getKvPairs (): Readonly<JsonObject> | null {
         try {
             const kvPairs = JSON.parse(this.message) as JsonValue;
             if (false === isJsonObject(kvPairs)) {
-                console.warn(
-                    `Log event message is not a JSON object. Log event index: ${this.logEventIdx}.`
-                );
-
                 return null;
             }
 
             return kvPairs;
-        } catch (error) {
-            console.warn(
-                `Failed to parse log event message as JSON. Log event index: ${this.logEventIdx}.`,
-                error
-            );
-
+        } catch {
             return null;
         }
     }

--- a/src/clp_ffi_js/sfa/LogEvent.ts
+++ b/src/clp_ffi_js/sfa/LogEvent.ts
@@ -1,0 +1,58 @@
+import type {
+    JsonObject,
+    JsonValue,
+} from "./types.js";
+import {isJsonObject} from "./utils.js";
+
+
+/**
+ * Single log event from a CLP archive.
+ */
+class LogEvent {
+    readonly logEventIdx: bigint;
+
+    readonly timestamp: bigint;
+
+    readonly message: string;
+
+    /**
+     * @param logEventIdx Global log event index.
+     * @param timestamp Epoch timestamp.
+     * @param message Serialized message string.
+     */
+    constructor (logEventIdx: bigint, timestamp: bigint, message: string) {
+        this.logEventIdx = logEventIdx;
+        this.timestamp = timestamp;
+        this.message = message;
+    }
+
+    /**
+     * Returns the key-value pairs of this log event by parsing the message as JSON.
+     *
+     * @return The key-value pairs, or null if the message is not a JSON object.
+     */
+    getKvPairs (): Readonly<JsonObject> | null {
+        try {
+            const kvPairs = JSON.parse(this.message) as JsonValue;
+            if (false === isJsonObject(kvPairs)) {
+                console.warn(
+                    `Log event message is not a JSON object. Log event index: ${this.logEventIdx}.`
+                );
+
+                return null;
+            }
+
+            return kvPairs;
+        } catch (error) {
+            console.warn(
+                `Failed to parse log event message as JSON. Log event index: ${this.logEventIdx}.`,
+                error
+            );
+
+            return null;
+        }
+    }
+}
+
+
+export {LogEvent};

--- a/src/clp_ffi_js/sfa/SfaReader.cpp
+++ b/src/clp_ffi_js/sfa/SfaReader.cpp
@@ -66,12 +66,39 @@ auto SfaReader::get_file_infos() const -> FileInfoArrayTsType {
     }
     return FileInfoArrayTsType{file_infos};
 }
+
+auto SfaReader::decode_all() -> LogEventArrayTsType {
+    auto decoded_result{m_reader.decode_all()};
+    if (decoded_result.has_error()) {
+        auto const error{decoded_result.error()};
+        auto const err_msg{fmt::format(
+                "Failed to decode SFA archive: {} - {}.",
+                error.category().name(),
+                error.message()
+        )};
+        SPDLOG_ERROR("{}", err_msg);
+        throw std::runtime_error{err_msg};
+    }
+
+    auto decoded_events{emscripten::val::array()};
+    for (auto const& event : decoded_result.value()) {
+        auto entry{emscripten::val::object()};
+        entry.set("logEventIdx", emscripten::val(event.get_log_event_idx()));
+        entry.set("timestamp", emscripten::val(event.get_timestamp()));
+        entry.set("message", emscripten::val(event.get_message()));
+        decoded_events.call<void>("push", entry);
+    }
+    return LogEventArrayTsType{decoded_events};
+}
 }  // namespace clp_ffi_js::sfa
 
 EMSCRIPTEN_BINDINGS(SfaReader) {
     emscripten::register_type<clp_ffi_js::sfa::FileInfoArrayTsType>(
             "Array<{fileName: string, logEventIdxStart: bigint, logEventIdxEnd: bigint, "
             "logEventCount: bigint}>"
+    );
+    emscripten::register_type<clp_ffi_js::sfa::LogEventArrayTsType>(
+            "Array<{logEventIdx: bigint, timestamp: bigint, message: string}>"
     );
 
     emscripten::class_<clp_ffi_js::sfa::SfaReader>("ClpSfaReader")
@@ -81,5 +108,6 @@ EMSCRIPTEN_BINDINGS(SfaReader) {
             )
             .function("getEventCount", &clp_ffi_js::sfa::SfaReader::get_event_count)
             .function("getFileNames", &clp_ffi_js::sfa::SfaReader::get_file_names)
-            .function("getFileInfos", &clp_ffi_js::sfa::SfaReader::get_file_infos);
+            .function("getFileInfos", &clp_ffi_js::sfa::SfaReader::get_file_infos)
+            .function("decodeAll", &clp_ffi_js::sfa::SfaReader::decode_all);
 }

--- a/src/clp_ffi_js/sfa/SfaReader.hpp
+++ b/src/clp_ffi_js/sfa/SfaReader.hpp
@@ -12,6 +12,7 @@
 
 namespace clp_ffi_js::sfa {
 EMSCRIPTEN_DECLARE_VAL_TYPE(FileInfoArrayTsType);
+EMSCRIPTEN_DECLARE_VAL_TYPE(LogEventArrayTsType);
 
 class SfaReader {
 public:
@@ -30,6 +31,8 @@ public:
     [[nodiscard]] auto get_file_names() const -> clp_ffi_js::StringArrayTsType;
 
     [[nodiscard]] auto get_file_infos() const -> FileInfoArrayTsType;
+
+    [[nodiscard]] auto decode_all() -> LogEventArrayTsType;
 
 private:
     explicit SfaReader(clp_s::ffi::sfa::ClpArchiveReader&& reader) : m_reader(std::move(reader)) {}

--- a/src/clp_ffi_js/sfa/index.ts
+++ b/src/clp_ffi_js/sfa/index.ts
@@ -1,5 +1,8 @@
 export {ClpArchiveReader} from "./ClpArchiveReader.js";
-export type {FileInfo} from "./types.js";
+export {LogEvent} from "./LogEvent.js";
+export type {
+    FileInfo, JsonObject, JsonValue,
+} from "./types.js";
 export {
     CLP_SFA_MAGIC_BYTES,
     isClpJsonSingleFileArchive,

--- a/src/clp_ffi_js/sfa/types.ts
+++ b/src/clp_ffi_js/sfa/types.ts
@@ -9,6 +9,15 @@ interface FileInfo {
 }
 
 /**
+ * Data used to construct a `LogEvent`.
+ */
+interface RawLogEvent {
+    logEventIdx: bigint;
+    timestamp: bigint;
+    message: string;
+}
+
+/**
  * Type for values in a JSON object/array.
  * Reference: https://www.json.org/json-en.html
  */
@@ -33,4 +42,5 @@ export type {
     FileInfo,
     JsonObject,
     JsonValue,
+    RawLogEvent,
 };

--- a/src/clp_ffi_js/sfa/types.ts
+++ b/src/clp_ffi_js/sfa/types.ts
@@ -8,4 +8,29 @@ interface FileInfo {
     logEventCount: bigint;
 }
 
-export type {FileInfo};
+/**
+ * Type for values in a JSON object/array.
+ * Reference: https://www.json.org/json-en.html
+ */
+type JsonValue = null |
+    string |
+    number |
+    boolean |
+    {
+        [key: string]: JsonValue;
+    } |
+    Array<JsonValue>;
+
+/**
+ * JSON object type.
+ * Reference: https://www.json.org/json-en.html
+ */
+type JsonObject = {
+    [key: string]: JsonValue;
+};
+
+export type {
+    FileInfo,
+    JsonObject,
+    JsonValue,
+};

--- a/src/clp_ffi_js/sfa/utils.ts
+++ b/src/clp_ffi_js/sfa/utils.ts
@@ -1,3 +1,9 @@
+import type {
+    JsonObject,
+    JsonValue,
+} from "./types.js";
+
+
 /**
  * Starting byte sequence that identifies a CLP JSON single-file archive (SFA).
  */
@@ -24,7 +30,19 @@ const isClpJsonSingleFileArchive = (input: ArrayBuffer | ArrayBufferView): boole
     return CLP_SFA_MAGIC_BYTES.every((value, index) => bytes[index] === value);
 };
 
+/**
+ * Determines whether the given value is a `JsonObject` and applies a TypeScript narrowing
+ * conversion if so.
+ *
+ * @param value
+ * @return A TypeScript type predicate indicating whether `value` is a `JsonObject`.
+ */
+const isJsonObject = (value: JsonValue): value is JsonObject => {
+    return "object" === typeof value && null !== value && false === Array.isArray(value);
+};
+
 export {
     CLP_SFA_MAGIC_BYTES,
     isClpJsonSingleFileArchive,
+    isJsonObject,
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Adds the native decodeAll binding and returns raw event objects across the WASM boundary. ClpArchiveReader wraps each raw event in a public LogEvent class with read-only accessors and getKvPairs() support for parsing structured JSON messages.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] lint and unit tests. pass.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added decoding of all archive log events in a single call.
  - Introduced a `LogEvent` object model (index, timestamp, message) and exposed it publicly.
  - Added optional JSON parsing for log event messages, including runtime validation that the parsed value is a JSON object.
  - Exported shared JSON typing utilities (`JsonValue`, `JsonObject`, and `RawLogEvent`) and a new `isJsonObject` helper for downstream use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->